### PR TITLE
k8s dashboards

### DIFF
--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
@@ -1,20 +1,20 @@
 terraform {
-    required_providers {
-        lightstep = {
-            source = "lightstep/lightstep"
-            version = "~> 1.60.2"
-        }
+  required_providers {
+    lightstep = {
+      source  = "lightstep/lightstep"
+      version = "~> 1.60.2"
     }
-    required_version = ">= v1.0.11"
+  }
+  required_version = ">= v1.0.11"
 }
 
 provider "lightstep" {
-    api_key         = var.api_key
-    organization    = var.organization
+  api_key      = var.api_key
+  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
-  project_name = var.lightstep_project
+  project_name   = var.lightstep_project
   dashboard_name = "Kubelet (imported)"
 
   chart {
@@ -23,10 +23,10 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
+      query_name = "a"
       // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
-      display             = "line"
-      hidden              = false
+      display = "line"
+      hidden  = false
 
       metric              = "kubelet_node_name"
       timeseries_operator = "last"
@@ -34,7 +34,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -47,10 +47,10 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
+      query_name = "a"
       // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
-      display             = "line"
-      hidden              = false
+      display = "line"
+      hidden  = false
 
       metric              = "kubelet_running_pods"
       timeseries_operator = "last"
@@ -58,7 +58,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -71,10 +71,10 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
+      query_name = "a"
       // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
-      display             = "line"
-      hidden              = false
+      display = "line"
+      hidden  = false
 
       metric              = "kubelet_running_containers"
       timeseries_operator = "last"
@@ -82,7 +82,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -95,10 +95,10 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
+      query_name = "a"
       // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
-      display             = "line"
-      hidden              = false
+      display = "line"
+      hidden  = false
 
       metric              = "volume_manager_total_volumes"
       timeseries_operator = "last"
@@ -106,7 +106,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -119,10 +119,10 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
+      query_name = "a"
       // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
-      display             = "line"
-      hidden              = false
+      display = "line"
+      hidden  = false
 
       metric              = "volume_manager_total_volumes"
       timeseries_operator = "last"
@@ -130,7 +130,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -143,9 +143,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_runtime_operations_total"
       timeseries_operator = "rate"
@@ -153,7 +153,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["operation_type",]
+        keys               = ["operation_type", ]
       }
 
     }
@@ -166,9 +166,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_runtime_operations_errors_total"
       timeseries_operator = "rate"
@@ -176,7 +176,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -189,9 +189,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_runtime_operations_duration_seconds"
       timeseries_operator = "delta"
@@ -199,7 +199,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["instance","operation_type",]
+        keys               = ["instance", "operation_type", ]
       }
 
     }
@@ -212,9 +212,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_pod_worker_duration_seconds"
       timeseries_operator = "delta"
@@ -222,15 +222,15 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["service",]
+        keys               = ["service", ]
       }
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = false
+      query_name = "b"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_pod_start_duration_seconds"
       timeseries_operator = "delta"
@@ -238,7 +238,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -251,9 +251,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "storage_operation_duration_seconds"
       timeseries_operator = "delta"
@@ -261,7 +261,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["instance","operation_name","volume_plugin",]
+        keys               = ["instance", "operation_name", "volume_plugin", ]
       }
 
     }
@@ -274,9 +274,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_cgroup_manager_duration_seconds"
       timeseries_operator = "delta"
@@ -284,7 +284,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["instance","operation_type",]
+        keys               = ["instance", "operation_type", ]
       }
 
     }
@@ -297,9 +297,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_pleg_relist_interval_seconds"
       timeseries_operator = "delta"
@@ -307,7 +307,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["instance",]
+        keys               = ["instance", ]
       }
 
     }
@@ -320,9 +320,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kubelet_pleg_relist_duration_seconds"
       timeseries_operator = "delta"
@@ -330,7 +330,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["instance",]
+        keys               = ["instance", ]
       }
 
     }
@@ -343,9 +343,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "rest_client_requests_total"
       timeseries_operator = "rate"
@@ -353,15 +353,15 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = false
+      query_name = "b"
+      display    = "line"
+      hidden     = false
 
       metric              = "rest_client_requests_total"
       timeseries_operator = "rate"
@@ -369,15 +369,15 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
 
     query {
-      query_name          = "c"
-      display             = "line"
-      hidden              = false
+      query_name = "c"
+      display    = "line"
+      hidden     = false
 
       metric              = "rest_client_requests_total"
       timeseries_operator = "rate"
@@ -385,7 +385,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -398,9 +398,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "rest_client_request_duration_seconds"
       timeseries_operator = "delta"
@@ -408,7 +408,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["verb",]
+        keys               = ["verb", ]
       }
 
     }
@@ -421,9 +421,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "process_resident_memory_bytes"
       timeseries_operator = "last"
@@ -431,7 +431,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -444,9 +444,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "process_cpu_seconds_total"
       timeseries_operator = "rate"
@@ -454,7 +454,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "avg"
-        keys = ["instance",]
+        keys               = ["instance", ]
       }
 
     }
@@ -467,9 +467,9 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "go_goroutines"
       timeseries_operator = "last"
@@ -477,7 +477,7 @@ resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
 
       group_by {
         aggregation_method = "avg"
-        keys = ["instance",]
+        keys               = ["instance", ]
       }
 
     }

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
@@ -1,0 +1,487 @@
+terraform {
+    required_providers {
+        lightstep = {
+            source = "lightstep/lightstep"
+            version = "~> 1.60.2"
+        }
+    }
+    required_version = ">= v1.0.11"
+}
+
+provider "lightstep" {
+    api_key         = var.api_key
+    organization    = var.organization
+}
+
+resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {
+  project_name = var.lightstep_project
+  dashboard_name = "Kubelet (imported)"
+
+  chart {
+    name = "Running Kubelets"
+    rank = "0"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_node_name"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Running Pods"
+    rank = "1"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_running_pods"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Running Containers"
+    rank = "2"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_running_containers"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Actual Volume Count"
+    rank = "3"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
+      display             = "line"
+      hidden              = false
+
+      metric              = "volume_manager_total_volumes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Desired Volume Count"
+    rank = "4"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      // NOTE: in the kube-prometheus-stack Grafana templates a big_number is used for display
+      display             = "line"
+      hidden              = false
+
+      metric              = "volume_manager_total_volumes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Operation Rate"
+    rank = "5"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_runtime_operations_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["operation_type",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Operation Error Rate"
+    rank = "6"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_runtime_operations_errors_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Operation duration (p99)"
+    rank = "7"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_runtime_operations_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["instance","operation_type",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Pod Start Duration (p95)"
+    rank = "8"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_pod_worker_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["service",]
+      }
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_pod_start_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Storage Operation Duration (p99)"
+    rank = "9"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "storage_operation_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["instance","operation_name","volume_plugin",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Cgroup manager duration seconds (p99)"
+    rank = "10"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_cgroup_manager_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["instance","operation_type",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "PLEG relist interval (p99)"
+    rank = "11"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_pleg_relist_interval_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["instance",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "PLEG relist duration (p99)"
+    rank = "12"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kubelet_pleg_relist_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["instance",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "RPC Rates (2xx, 4xx, 5xx)"
+    rank = "13"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "rest_client_requests_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = false
+
+      metric              = "rest_client_requests_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+    query {
+      query_name          = "c"
+      display             = "line"
+      hidden              = false
+
+      metric              = "rest_client_requests_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Request duration (p99)"
+    rank = "14"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "rest_client_request_duration_seconds"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["verb",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Memory"
+    rank = "15"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "process_resident_memory_bytes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "CPU Usage"
+    rank = "16"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "process_cpu_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "avg"
+        keys = ["instance",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Goroutines"
+    rank = "17"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "go_goroutines"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "avg"
+        keys = ["instance",]
+      }
+
+    }
+
+  }
+
+}

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value         = "https://app.lightstep.com/${var.project}/dashboard/${lightstep_metric_dashboard.k8s_kubelet_dashboard.id}"
-  description   = "k8s resources"
+  value       = "https://app.lightstep.com/${var.project}/dashboard/${lightstep_metric_dashboard.k8s_kubelet_dashboard.id}"
+  description = "k8s resources"
 }

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard_url" {
+  value         = "https://app.lightstep.com/${var.project}/dashboard/${lightstep_metric_dashboard.k8s_kubelet_dashboard.id}"
+  description   = "k8s resources"
+}

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
@@ -1,14 +1,14 @@
 variable "lightstep_project" {
   description = "Lightstep Project Name"
-  type = string
+  type        = string
 }
 
 variable "api_key" {
   description = "API Key"
-  type = string
-}  
+  type        = string
+}
 
 variable "organization" {
   description = "The organization that owns your account."
-  type = string
+  type        = string
 }

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
@@ -1,0 +1,14 @@
+variable "lightstep_project" {
+  description = "Lightstep Project Name"
+  type = string
+}
+
+variable "api_key" {
+  description = "API Key"
+  type = string
+}  
+
+variable "organization" {
+  description = "The organization that owns your account."
+  type = string
+}

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
@@ -1,0 +1,465 @@
+terraform {
+    required_providers {
+        lightstep = {
+            source = "lightstep/lightstep"
+            version = "~> 1.60.2"
+        }
+    }
+    required_version = ">= v1.0.11"
+}
+
+provider "lightstep" {
+    api_key         = var.api_key
+    organization    = var.organization
+}
+
+resource "lightstep_metric_dashboard" "k8s_node_exporter_dashboard" {
+  project_name   = var.lightstep_project
+  dashboard_name = "Node Exporter (import)"
+
+  chart {
+    name = "Load Average"
+    rank = "0"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_load1"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "min"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_load5"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "min"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "c"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_load15"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "min"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "d"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_cpu_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "CPU Usage"
+    rank = "1"
+    type = "timeseries"
+
+    query {
+      query_name = "1 - a / b"
+      display    = "line"
+      hidden     = false
+
+    }
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_cpu_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = ["cpu", ]
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_cpu_seconds_total"
+      timeseries_operator = "delta"
+
+
+      group_by {
+        aggregation_method = "count"
+        keys               = ["cpu", ]
+      }
+
+    }
+
+  }
+
+  // NOTE: The Grafana Dashboard in kube-prometheus-stack uses a big_number
+  // type of display.
+  chart {
+    name = "Memory Usage"
+    rank = "2"
+    type = "timeseries"
+
+    query {
+      query_name = "100 - a / b * 100"
+      display    = "line"
+      hidden     = false
+
+    }
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_memory_MemAvailable_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_memory_MemTotal_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Memory Usage"
+    rank = "3"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_memory_MemTotal_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "a - f - e"
+      display    = "line"
+      hidden     = false
+
+    }
+
+    query {
+      query_name = "d"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_memory_Buffers_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "e"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_memory_Cached_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "f"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_memory_MemFree_bytes"
+      timeseries_operator = "avg"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Disk I/O (Bytes)"
+    rank = "4"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_disk_read_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_disk_written_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "c"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_disk_io_time_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Disk I/O (seconds)"
+    rank = "5"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_disk_io_time_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_disk_discard_time_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+    query {
+      query_name = "c"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_disk_flush_requests_time_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys               = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Disk Space Usage"
+    rank = "6"
+    type = "timeseries"
+
+    query {
+      query_name = "1 - b / a"
+      display    = "line"
+      hidden     = false
+
+    }
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_filesystem_size_bytes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "max"
+        keys               = ["mountpoint", ]
+      }
+
+    }
+
+    query {
+      query_name = "b"
+      display    = "line"
+      hidden     = true
+
+      metric              = "node_filesystem_avail_bytes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "max"
+        keys               = ["mountpoint", ]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Network Received"
+    rank = "7"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_network_receive_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "avg"
+        keys               = ["device", ]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Network Transmitted"
+    rank = "8"
+    type = "timeseries"
+
+    query {
+      query_name = "a"
+      display    = "line"
+      hidden     = false
+
+      metric              = "node_network_transmit_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "avg"
+        keys               = ["device", ]
+      }
+
+    }
+
+  }
+
+}

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
@@ -1,16 +1,16 @@
 terraform {
-    required_providers {
-        lightstep = {
-            source = "lightstep/lightstep"
-            version = "~> 1.60.2"
-        }
+  required_providers {
+    lightstep = {
+      source  = "lightstep/lightstep"
+      version = "~> 1.60.2"
     }
-    required_version = ">= v1.0.11"
+  }
+  required_version = ">= v1.0.11"
 }
 
 provider "lightstep" {
-    api_key         = var.api_key
-    organization    = var.organization
+  api_key      = var.api_key
+  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_node_exporter_dashboard" {

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard_url" {
+  value         = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_node_exporter_dashboard.id}"
+  description   = "k8s resources"
+}

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value         = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_node_exporter_dashboard.id}"
-  description   = "k8s resources"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_node_exporter_dashboard.id}"
+  description = "k8s resources"
 }

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
@@ -1,14 +1,14 @@
 variable "project" {
   description = "Lightstep Project Name"
-  type = string
+  type        = string
 }
 
 variable "api_key" {
   description = "API Key"
-  type = string
-}  
+  type        = string
+}
 
 variable "organization" {
   description = "The organization that owns your account."
-  type = string
+  type        = string
 }

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
@@ -1,0 +1,14 @@
+variable "project" {
+  description = "Lightstep Project Name"
+  type = string
+}
+
+variable "api_key" {
+  description = "API Key"
+  type = string
+}  
+
+variable "organization" {
+  description = "The organization that owns your account."
+  type = string
+}

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
@@ -1,0 +1,535 @@
+terraform {
+    required_providers {
+        lightstep = {
+            source = "lightstep/lightstep"
+            version = "~> 1.60.2"
+        }
+    }
+    required_version = ">= v1.0.11"
+}
+
+provider "lightstep" {
+    api_key         = var.api_key
+    organization    = var.organization
+}
+
+resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
+  project_name = var.lightstep_project
+  dashboard_name = "Kubernetes Resources - Pod (import)"
+
+  chart {
+    name = "CPU Usage - Seconds"
+    rank = "0"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_cpu_usage_seconds_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "avg"
+        keys = ["container",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "CPU Usage - Limits/Requests"
+    rank = "1"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kube_pod_container_resource_requests"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kube_pod_container_resource_limits"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "CPU Throttling"
+    rank = "2"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "area"
+      hidden              = true
+
+      metric              = "container_cpu_cfs_throttled_periods_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+    query {
+      query_name          = "a / b"
+      display             = "area"
+      hidden              = false
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "area"
+      hidden              = true
+
+      metric              = "container_cpu_cfs_periods_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Memory Usage (WSS)- Bytes"
+    rank = "3"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_memory_working_set_bytes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Memory Usage (WSS) - Limits/Requests"
+    rank = "4"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kube_pod_container_resource_requests"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = false
+
+      metric              = "kube_pod_container_resource_limits"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = []
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Memory Usage by Container"
+    rank = "5"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "bar"
+      hidden              = false
+
+      metric              = "container_memory_working_set_bytes"
+      timeseries_operator = "last"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Receive Bandwidth"
+    rank = "6"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_receive_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Transmit Bandwidth"
+    rank = "7"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_transmit_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Rate of Received Packets"
+    rank = "8"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_receive_packets_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Rate of Transmitted Packets"
+    rank = "9"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_transmit_packets_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Rate of Received Packets Dropped"
+    rank = "10"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_receive_packets_dropped_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "Rate of Transmitted Packets Dropped"
+    rank = "11"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = false
+
+      metric              = "container_network_transmit_packets_dropped_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "IOPS (Pods)"
+    rank = "12"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_writes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+    query {
+      query_name          = "a + b"
+      display             = "line"
+      hidden              = false
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_reads_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "ThroughPut (Pods)"
+    rank = "13"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_writes_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+    query {
+      query_name          = "a + b"
+      display             = "line"
+      hidden              = false
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_reads_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["pod",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "IOPS (Containers)"
+    rank = "14"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_writes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+    query {
+      query_name          = "a + b"
+      display             = "line"
+      hidden              = false
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_reads_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+  }
+
+  chart {
+    name = "ThroughPut (Containers)"
+    rank = "15"
+    type = "timeseries"
+
+    query {
+      query_name          = "a"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_writes_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+    query {
+      query_name          = "a + b"
+      display             = "line"
+      hidden              = false
+
+    }
+
+    query {
+      query_name          = "b"
+      display             = "line"
+      hidden              = true
+
+      metric              = "container_fs_reads_bytes_total"
+      timeseries_operator = "rate"
+
+
+      group_by {
+        aggregation_method = "sum"
+        keys = ["container",]
+      }
+
+    }
+
+  }
+
+}

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
@@ -1,20 +1,20 @@
 terraform {
-    required_providers {
-        lightstep = {
-            source = "lightstep/lightstep"
-            version = "~> 1.60.2"
-        }
+  required_providers {
+    lightstep = {
+      source  = "lightstep/lightstep"
+      version = "~> 1.60.2"
     }
-    required_version = ">= v1.0.11"
+  }
+  required_version = ">= v1.0.11"
 }
 
 provider "lightstep" {
-    api_key         = var.api_key
-    organization    = var.organization
+  api_key      = var.api_key
+  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
-  project_name = var.lightstep_project
+  project_name   = var.lightstep_project
   dashboard_name = "Kubernetes Resources - Pod (import)"
 
   chart {
@@ -23,9 +23,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_cpu_usage_seconds_total"
       timeseries_operator = "rate"
@@ -33,7 +33,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "avg"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
@@ -46,9 +46,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kube_pod_container_resource_requests"
       timeseries_operator = "last"
@@ -56,15 +56,15 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = false
+      query_name = "b"
+      display    = "line"
+      hidden     = false
 
       metric              = "kube_pod_container_resource_limits"
       timeseries_operator = "last"
@@ -72,7 +72,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -85,9 +85,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "area"
-      hidden              = true
+      query_name = "a"
+      display    = "area"
+      hidden     = true
 
       metric              = "container_cpu_cfs_throttled_periods_total"
       timeseries_operator = "rate"
@@ -95,22 +95,22 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
 
     query {
-      query_name          = "a / b"
-      display             = "area"
-      hidden              = false
+      query_name = "a / b"
+      display    = "area"
+      hidden     = false
 
     }
 
     query {
-      query_name          = "b"
-      display             = "area"
-      hidden              = true
+      query_name = "b"
+      display    = "area"
+      hidden     = true
 
       metric              = "container_cpu_cfs_periods_total"
       timeseries_operator = "rate"
@@ -118,7 +118,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -131,9 +131,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_memory_working_set_bytes"
       timeseries_operator = "last"
@@ -141,7 +141,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
@@ -154,9 +154,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "kube_pod_container_resource_requests"
       timeseries_operator = "last"
@@ -164,15 +164,15 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = false
+      query_name = "b"
+      display    = "line"
+      hidden     = false
 
       metric              = "kube_pod_container_resource_limits"
       timeseries_operator = "last"
@@ -180,7 +180,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = []
+        keys               = []
       }
 
     }
@@ -193,9 +193,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "bar"
-      hidden              = false
+      query_name = "a"
+      display    = "bar"
+      hidden     = false
 
       metric              = "container_memory_working_set_bytes"
       timeseries_operator = "last"
@@ -203,7 +203,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
@@ -216,9 +216,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_receive_bytes_total"
       timeseries_operator = "rate"
@@ -226,7 +226,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -239,9 +239,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_transmit_bytes_total"
       timeseries_operator = "rate"
@@ -249,7 +249,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -262,9 +262,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_receive_packets_total"
       timeseries_operator = "rate"
@@ -272,7 +272,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -285,9 +285,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_transmit_packets_total"
       timeseries_operator = "rate"
@@ -295,7 +295,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -308,9 +308,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_receive_packets_dropped_total"
       timeseries_operator = "rate"
@@ -318,7 +318,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -331,9 +331,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = false
+      query_name = "a"
+      display    = "line"
+      hidden     = false
 
       metric              = "container_network_transmit_packets_dropped_total"
       timeseries_operator = "rate"
@@ -341,7 +341,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -354,9 +354,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = true
+      query_name = "a"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_writes_total"
       timeseries_operator = "rate"
@@ -364,22 +364,22 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
 
     query {
-      query_name          = "a + b"
-      display             = "line"
-      hidden              = false
+      query_name = "a + b"
+      display    = "line"
+      hidden     = false
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = true
+      query_name = "b"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_reads_total"
       timeseries_operator = "rate"
@@ -387,7 +387,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -400,9 +400,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = true
+      query_name = "a"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_writes_bytes_total"
       timeseries_operator = "rate"
@@ -410,22 +410,22 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
 
     query {
-      query_name          = "a + b"
-      display             = "line"
-      hidden              = false
+      query_name = "a + b"
+      display    = "line"
+      hidden     = false
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = true
+      query_name = "b"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_reads_bytes_total"
       timeseries_operator = "rate"
@@ -433,7 +433,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["pod",]
+        keys               = ["pod", ]
       }
 
     }
@@ -446,9 +446,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = true
+      query_name = "a"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_writes_total"
       timeseries_operator = "rate"
@@ -456,22 +456,22 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
 
     query {
-      query_name          = "a + b"
-      display             = "line"
-      hidden              = false
+      query_name = "a + b"
+      display    = "line"
+      hidden     = false
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = true
+      query_name = "b"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_reads_total"
       timeseries_operator = "rate"
@@ -479,7 +479,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
@@ -492,9 +492,9 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
     type = "timeseries"
 
     query {
-      query_name          = "a"
-      display             = "line"
-      hidden              = true
+      query_name = "a"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_writes_bytes_total"
       timeseries_operator = "rate"
@@ -502,22 +502,22 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }
 
     query {
-      query_name          = "a + b"
-      display             = "line"
-      hidden              = false
+      query_name = "a + b"
+      display    = "line"
+      hidden     = false
 
     }
 
     query {
-      query_name          = "b"
-      display             = "line"
-      hidden              = true
+      query_name = "b"
+      display    = "line"
+      hidden     = true
 
       metric              = "container_fs_reads_bytes_total"
       timeseries_operator = "rate"
@@ -525,7 +525,7 @@ resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {
 
       group_by {
         aggregation_method = "sum"
-        keys = ["container",]
+        keys               = ["container", ]
       }
 
     }

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/outputs.tf
@@ -1,4 +1,4 @@
 output "dashboard_url" {
-  value         = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_resources_pod_dashboard.id}"
-  description   = "k8s resources"
+  value       = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_resources_pod_dashboard.id}"
+  description = "k8s resources"
 }

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/outputs.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/outputs.tf
@@ -1,0 +1,4 @@
+output "dashboard_url" {
+  value         = "https://app.lightstep.com/${var.lightstep_project}/dashboard/${lightstep_metric_dashboard.k8s_resources_pod_dashboard.id}"
+  description   = "k8s resources"
+}

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
@@ -1,14 +1,14 @@
 variable "lightstep_project" {
   description = "Lightstep Project Name"
-  type = string
+  type        = string
 }
 
 variable "api_key" {
   description = "Lightstep API Key."
-  type = string
-}  
+  type        = string
+}
 
 variable "organization" {
   description = "The organization that owns your Lightstep  account."
-  type = string
+  type        = string
 }

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
@@ -1,0 +1,14 @@
+variable "lightstep_project" {
+  description = "Lightstep Project Name"
+  type = string
+}
+
+variable "api_key" {
+  description = "Lightstep API Key."
+  type = string
+}  
+
+variable "organization" {
+  description = "The organization that owns your Lightstep  account."
+  type = string
+}


### PR DESCRIPTION
There are 3 dashboards here for monitoring k8s. 
Each dashboard focuses on providing the same monitoring with the Lightstep app as a key dashboard in those provided in the kube-prometheus-stack at https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack/templates/grafana/dashboards-1.14.

This is the main deliverable for [LS-30968](https://lightstep.atlassian.net/browse/LS-30968) and each dashboard is the main deliverable for one of it's subtasks.