### PR TITLE
Upgrade to latest terraform provider, fix dashboards with missing metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .terraform
 *.tfstate
 *.tfstate.backup
+.terraform.lock.hcl
+main.tf

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -59,7 +59,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -84,7 +84,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -109,7 +109,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -134,7 +134,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -159,7 +159,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -184,7 +184,7 @@ The following shows an example Terraform configuration for various integrations:
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -211,7 +211,7 @@ Visit Lightstep to [Learn how to send telemetry from an OpenTelemetry Collector 
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -264,7 +264,7 @@ Visit Lightstep to [Learn how to send telemetry from an OpenTelemetry Collector 
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }
@@ -290,7 +290,7 @@ Visit Lightstep to [Learn how to send telemetry from an OpenTelemetry Collector 
     required_providers {
       lightstep = {
         source = "lightstep/lightstep"
-        version = "1.60.2"
+        version = "1.62.0"
       }
     }
   }

--- a/collector-dashboards/otel-collector-activedirectorydsreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-activedirectorydsreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-apachereceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-apachereceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-couchbasereceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-couchbasereceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-couchdbreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-couchdbreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -23,14 +23,16 @@ resource "lightstep_metric_dashboard" "otel_collector_dashboard" {
     rank = 1
     type = "timeseries"
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_process_uptime
-| rate
-| group_by [collector_name,job,service_instance_id], sum
-EOT
+      query_name      = "a"
+      exclude_filters = []
+      include_filters = []
+      display         = "bar"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_process_uptime
+        | rate
+        | group_by [collector_name,job,service_instance_id], sum
+        EOT
     }
   }
 
@@ -39,35 +41,40 @@ EOT
     rank = 2
     type = "timeseries"
     query {
-      query_name = "limits"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric kube_pod_container_resource_limits
-| latest
-| filter resource == "cpu"
-| filter container == "otc-container"
-| group_by [pod], sum
-EOT
+      query_name      = "limits"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric kube_pod_container_resource_limits
+        | latest
+        | filter resource == "cpu"
+        | filter container == "otc-container"
+        | group_by [pod], sum
+      EOT
     }
     query {
-      query_name = "request"
-      metric = "request"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric kube_pod_container_resource_requests
-| latest
-| filter resource == "cpu"
-| filter container == "otc-container"
-| group_by [pod], sum
-EOT
+      query_name      = "request"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric kube_pod_container_resource_requests
+        | latest
+        | filter resource == "cpu"
+        | filter container == "otc-container"
+        | group_by [pod], sum
+      EOT
     }
     query {
-      query_name = "usage"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
+      query_name      = "usage"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
     metric container_cpu_usage_seconds_total
     | rate
     | filter container == "otc-container"
@@ -82,34 +89,40 @@ EOT
     rank = 3
     type = "timeseries"
     query {
-      query_name = "limits"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric kube_pod_container_resource_limits
-| latest
-| filter resource == "memory"
-| filter container == "otc-container"
-| group_by [pod], sum
-EOT
+      query_name      = "limits"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric kube_pod_container_resource_limits
+        | latest
+        | filter resource == "memory"
+        | filter container == "otc-container"
+        | group_by [pod], sum
+      EOT
     }
     query {
-      query_name = "requests"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric kube_pod_container_resource_requests
-| latest
-| filter resource == "memory"
-| filter container == "otc-container"
-| group_by [pod], sum
-EOT
+      query_name      = "requests"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric kube_pod_container_resource_requests
+        | latest
+        | filter resource == "memory"
+        | filter container == "otc-container"
+        | group_by [pod], sum
+      EOT
     }
     query {
-      query_name = "usage"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
+      query_name      = "usage"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
     metric container_memory_working_set_bytes
     | latest
     | filter container == "otc-container"
@@ -124,45 +137,53 @@ EOT
     rank = 4
     type = "timeseries"
     query {
-      query_name = "accepted metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_receiver_accepted_metric_points
-| delta
-| group_by [receiver, collector_name], sum
-EOT
+      query_name      = "accepted metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_receiver_accepted_metric_points
+        | delta
+        | group_by [receiver, collector_name], sum
+      EOT
     }
     query {
-      query_name = "accepted spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_receiver_accepted_spans
-| delta
-| group_by [receiver, collector_name], sum
-EOT
+      query_name      = "accepted spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_receiver_accepted_spans
+        | delta
+        | group_by [receiver, collector_name], sum
+      EOT
     }
     query {
-      query_name = "refused metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_receiver_refused_metric_points
-| delta
-| group_by [receiver, collector_name], sum
-EOT
+      query_name      = "refused metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_receiver_refused_metric_points
+        | delta
+        | group_by [receiver, collector_name], sum
+      EOT
     }
 
     query {
-      query_name = "refused spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_receiver_refused_spans
-| delta
-| group_by [receiver, collector_name], sum
-EOT
+      query_name      = "refused spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_receiver_refused_spans
+        | delta
+        | group_by [receiver, collector_name], sum
+      EOT
     }
   }
 
@@ -172,44 +193,52 @@ EOT
     rank = 5
     type = "timeseries"
     query {
-      query_name = "dropped metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_processor_dropped_metric_points
-| delta
-| group_by [processor, collector_name], sum
-EOT
+      query_name      = "dropped metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_processor_dropped_metric_points
+        | delta
+        | group_by [processor, collector_name], sum
+      EOT
     }
     query {
-      query_name = "dropped spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_processor_dropped_spans
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "dropped spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_processor_dropped_spans
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
     query {
-      query_name = "refused metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_processor_refused_metric_points
-| delta
-| group_by [processor, collector_name], sum
-EOT
+      query_name      = "refused metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_processor_refused_metric_points
+        | delta
+        | group_by [processor, collector_name], sum
+      EOT
     }
     query {
-      query_name = "refused spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_processor_refused_spans
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "refused spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_processor_refused_spans
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
   }
 
@@ -219,44 +248,52 @@ EOT
     rank = 6
     type = "timeseries"
     query {
-      query_name = "sent metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_exporter_sent_metric_points
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "sent metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_exporter_sent_metric_points
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
     query {
-      query_name = "sent spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_exporter_sent_spans
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "sent spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_exporter_sent_spans
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
     query {
-      query_name = "failed metrics"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_exporter_send_failed_metric_points
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "failed metrics"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_exporter_send_failed_metric_points
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
     query {
-      query_name = "failed spans"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_exporter_send_failed_spans
-| delta
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "failed spans"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_exporter_send_failed_spans
+        | delta
+        | group_by [exporter, collector_name], sum
+      EOT
     }
   }
 
@@ -266,15 +303,17 @@ EOT
     rank = 7
     type = "timeseries"
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_processor_batch_batch_send_size
-| delta
-| group_by [processor, collector_name], sum
-| point percentile(value, 99)
-EOT
+      query_name      = "a"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_processor_batch_batch_send_size
+        | delta
+        | group_by [processor, collector_name], sum
+        | point percentile(value, 99)
+      EOT
     }
   }
 
@@ -283,14 +322,16 @@ EOT
     rank = 8
     type = "timeseries"
     query {
-      query_name = "a"
-      display    = "line"
-      hidden     = false
-      tql        = <<EOT
-metric otelcol_exporter_queue_size
-| latest
-| group_by [exporter, collector_name], sum
-EOT
+      query_name      = "a"
+      exclude_filters = []
+      include_filters = []
+      display         = "line"
+      hidden          = false
+      tql             = <<-EOT
+        metric otelcol_exporter_queue_size
+        | latest
+        | group_by [exporter, collector_name], sum
+      EOT
     }
   }
 
@@ -299,53 +340,59 @@ EOT
     rank = 9
     type = "timeseries"
     query {
-      query_name = "a"
-      display    = "bar"
-      hidden     = false
-      tql        = <<EOT
-metric lightstep.hourly_active_time_series
-| delta 1h
-| group_by [service.name], sum
-EOT
+      query_name      = "a"
+      exclude_filters = []
+      include_filters = []
+      display         = "bar"
+      hidden          = false
+      tql             = <<-EOT
+        metric lightstep.hourly_active_time_series
+        | delta 1h
+        | group_by [service.name], sum
+      EOT
     }
   }
 
   dynamic "chart" {
-    for_each = [ for addon in var.dashboard_addons: addon if addon == local.prometheus_addon ]
+    for_each = [for addon in var.dashboard_addons : addon if addon == local.prometheus_addon]
 
     content {
       name = "Prometheus targets by job, metrics_path"
       rank = 10
       type = "timeseries"
       query {
-        query_name = "a"
-        display    = "bar"
-        hidden     = false
-        tql        = <<EOT
-metric scrape_samples_scraped
-| reduce 1m, count
-| group_by [job, metrics_path], count
-EOT
+        query_name      = "a"
+        exclude_filters = []
+        include_filters = []
+        display         = "bar"
+        hidden          = false
+        tql             = <<-EOT
+          metric scrape_samples_scraped
+          | reduce 1m, count
+          | group_by [job, metrics_path], count
+        EOT
       }
     }
   }
 
   dynamic "chart" {
-    for_each = [ for addon in var.dashboard_addons: addon if addon == local.prometheus_addon ]
+    for_each = [for addon in var.dashboard_addons : addon if addon == local.prometheus_addon]
 
     content {
       name = "Receiver Scrape duration"
       rank = 11
       type = "timeseries"
       query {
-        query_name = "a"
-        display    = "line"
-        hidden     = false
-        tql        = <<EOT
-metric scrape_duration_seconds
-| latest
-| group_by [job], mean
-  EOT
+        query_name      = "a"
+        exclude_filters = []
+        include_filters = []
+        display         = "line"
+        hidden          = false
+        tql             = <<-EOT
+          metric scrape_duration_seconds
+          | latest
+          | group_by [job], mean
+        EOT
       }
     }
   }

--- a/collector-dashboards/otel-collector-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-dashboard/variables.tf
@@ -6,8 +6,8 @@ variable "lightstep_project" {
 
 variable "dashboard_addons" {
   description = "List of addons to add to the dashboard. Available addons: \"prometheus\"."
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
   validation {
     condition     = length(setsubtract(var.dashboard_addons, ["prometheus"])) == 0
     error_message = "Allowed values for dashboard_addons are: \"prometheus\"."

--- a/collector-dashboards/otel-collector-elasticsearchreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-elasticsearchreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-host-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-host-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-hostmetrics-cpu-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-hostmetrics-cpu-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-hostmetrics-disk-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-hostmetrics-disk-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-hostmetrics-memory-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-hostmetrics-memory-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-hostmetrics-paging-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-hostmetrics-paging-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-iisreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-iisreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
@@ -2,15 +2,10 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"
-}
-
-provider "lightstep" {
-  api_key      = var.api_key
-  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_kubelet_dashboard" {

--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/variables.tf
@@ -2,13 +2,3 @@ variable "lightstep_project" {
   description = "Lightstep Project Name"
   type        = string
 }
-
-variable "api_key" {
-  description = "API Key"
-  type        = string
-}
-
-variable "organization" {
-  description = "The organization that owns your account."
-  type        = string
-}

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
@@ -2,15 +2,10 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"
-}
-
-provider "lightstep" {
-  api_key      = var.api_key
-  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_node_exporter_dashboard" {

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/variables.tf
@@ -1,14 +1,4 @@
-variable "project" {
+variable "lightstep_project" {
   description = "Lightstep Project Name"
-  type        = string
-}
-
-variable "api_key" {
-  description = "API Key"
-  type        = string
-}
-
-variable "organization" {
-  description = "The organization that owns your account."
   type        = string
 }

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
@@ -2,15 +2,10 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"
-}
-
-provider "lightstep" {
-  api_key      = var.api_key
-  organization = var.organization
 }
 
 resource "lightstep_metric_dashboard" "k8s_resources_pod_dashboard" {

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/variables.tf
@@ -2,13 +2,3 @@ variable "lightstep_project" {
   description = "Lightstep Project Name"
   type        = string
 }
-
-variable "api_key" {
-  description = "Lightstep API Key."
-  type        = string
-}
-
-variable "organization" {
-  description = "The organization that owns your Lightstep  account."
-  type        = string
-}

--- a/collector-dashboards/otel-collector-kafka-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kafka-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-kafkametricsreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kafkametricsreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-kubeletstatsreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kubeletstatsreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-kubeletstatsreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kubeletstatsreceiver-dashboard/main.tf
@@ -15,7 +15,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     
     
     chart {
-      name = "cpu.time"
+      name = "container.cpu.time"
       rank = "0"
       type = "timeseries"
 
@@ -24,12 +24,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "cpu.time"
+        metric              = "container.cpu.time"
         timeseries_operator = "rate"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: CPU time
@@ -38,7 +38,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "cpu.utilization"
+      name = "container.cpu.utilization"
       rank = "1"
       type = "timeseries"
 
@@ -47,12 +47,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "cpu.utilization"
+        metric              = "container.cpu.utilization"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: CPU utilization
@@ -61,7 +61,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "filesystem.available"
+      name = "container.filesystem.available"
       rank = "2"
       type = "timeseries"
 
@@ -70,12 +70,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "filesystem.available"
+        metric              = "container.filesystem.available"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Filesystem available
@@ -84,7 +84,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "filesystem.capacity"
+      name = "container.filesystem.capacity"
       rank = "3"
       type = "timeseries"
 
@@ -93,12 +93,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "filesystem.capacity"
+        metric              = "container.filesystem.capacity"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Filesystem capacity
@@ -107,7 +107,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "filesystem.usage"
+      name = "container.filesystem.usage"
       rank = "4"
       type = "timeseries"
 
@@ -116,12 +116,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "filesystem.usage"
+        metric              = "container.filesystem.usage"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Filesystem usage
@@ -130,7 +130,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.available"
+      name = "container.memory.available"
       rank = "5"
       type = "timeseries"
 
@@ -139,12 +139,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.available"
+        metric              = "container.memory.available"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory available
@@ -153,7 +153,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.major_page_faults"
+      name = "container.memory.major_page_faults"
       rank = "6"
       type = "timeseries"
 
@@ -162,12 +162,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.major_page_faults"
+        metric              = "container.memory.major_page_faults"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory major_page_faults
@@ -176,7 +176,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.page_faults"
+      name = "container.memory.page_faults"
       rank = "7"
       type = "timeseries"
 
@@ -185,12 +185,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.page_faults"
+        metric              = "container.memory.page_faults"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory page_faults
@@ -199,7 +199,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.rss"
+      name = "container.memory.rss"
       rank = "8"
       type = "timeseries"
 
@@ -208,12 +208,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.rss"
+        metric              = "container.memory.rss"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory rss
@@ -222,7 +222,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.usage"
+      name = "container.memory.usage"
       rank = "9"
       type = "timeseries"
 
@@ -231,12 +231,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.usage"
+        metric              = "container.memory.usage"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory usage
@@ -245,7 +245,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "memory.working_set"
+      name = "container.memory.working_set"
       rank = "10"
       type = "timeseries"
 
@@ -254,12 +254,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "memory.working_set"
+        metric              = "container.memory.working_set"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: Memory working_set
@@ -268,7 +268,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "network.errors"
+      name = "k8s.pod.network.errors"
       rank = "11"
       type = "timeseries"
 
@@ -277,7 +277,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "network.errors"
+        metric              = "k8s.pod.network.errors"
         timeseries_operator = "rate"
 
         group_by {
@@ -291,7 +291,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "network.io"
+      name = "k8s.pod.network.io"
       rank = "12"
       type = "timeseries"
 
@@ -300,7 +300,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "network.io"
+        metric              = "k8s.pod.network.io"
         timeseries_operator = "rate"
 
         group_by {
@@ -314,7 +314,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "volume.available"
+      name = "k8s.volume.available"
       rank = "13"
       type = "timeseries"
 
@@ -323,12 +323,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "volume.available"
+        metric              = "k8s.volume.available"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: The number of available bytes in the volume.
@@ -337,7 +337,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "volume.capacity"
+      name = "k8s.volume.capacity"
       rank = "14"
       type = "timeseries"
 
@@ -346,12 +346,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "volume.capacity"
+        metric              = "k8s.volume.capacity"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: The total capacity in bytes of the volume.
@@ -360,7 +360,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "volume.inodes"
+      name = "k8s.volume.inodes"
       rank = "15"
       type = "timeseries"
 
@@ -369,12 +369,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "volume.inodes"
+        metric              = "k8s.volume.inodes"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: The total inodes in the filesystem.
@@ -383,7 +383,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "volume.inodes.free"
+      name = "k8s.volume.inodes.free"
       rank = "16"
       type = "timeseries"
 
@@ -392,12 +392,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "volume.inodes.free"
+        metric              = "k8s.volume.inodes.free"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: The free inodes in the filesystem.
@@ -406,7 +406,7 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
     }
     
     chart {
-      name = "volume.inodes.used"
+      name = "k8s.volume.inodes.used"
       rank = "17"
       type = "timeseries"
 
@@ -415,12 +415,12 @@ resource "lightstep_metric_dashboard" "otel_collector_kubeletstatsreceiver_dashb
         display    = "line"
         hidden     = false
 
-        metric              = "volume.inodes.used"
+        metric              = "k8s.volume.inodes.used"
         timeseries_operator = "last"
 
         group_by {
           aggregation_method = "sum"
-          keys               = []
+          keys               = ["k8s.pod.name", "k8s.namespace.name"]
         }
         
         # TODO: add description: The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems.

--- a/collector-dashboards/otel-collector-kubernetes-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kubernetes-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-memcachedreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-memcachedreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-mongodbatlasreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-mongodbatlasreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-mongodbreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-mongodbreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-mysqlreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-mysqlreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-nginxreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-nginxreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-postgresqlreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-postgresqlreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-rabbitmqreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-rabbitmqreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-redisreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-redisreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-riakreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-riakreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-sqlserverreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-sqlserverreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-tomcat-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-tomcat-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-collector-zookeeperreceiver-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-zookeeperreceiver-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.60.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-operator-dashboard/main.tf
+++ b/collector-dashboards/otel-operator-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.61.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"

--- a/collector-dashboards/otel-target-allocator-dashboard/main.tf
+++ b/collector-dashboards/otel-target-allocator-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.61.2"
+      version = "~> 1.62.0"
     }
   }
   required_version = ">= v1.0.11"
@@ -77,16 +77,13 @@ resource "lightstep_metric_dashboard" "otel_target_allocator_dashboard" {
             exclude_filters     = []
             hidden              = false
             include_filters     = []
-            metric              = "opentelemetry_allocator_time_to_allocate"
             query_name          = "a"
-            timeseries_operator = "delta"
-
-            group_by {
-                aggregation_method = "sum"
-                keys               = [
-                    "method",
-                ]
-            }
+            tql                 = <<-EOT
+                metric opentelemetry_allocator_time_to_allocate
+                | delta 5m
+                | group_by [method], sum
+                | point percentile(value, 50.0), percentile(value, 95.0), percentile(value, 99.0)
+            EOT
         }
     }
     chart {
@@ -143,16 +140,13 @@ resource "lightstep_metric_dashboard" "otel_target_allocator_dashboard" {
             exclude_filters     = []
             hidden              = false
             include_filters     = []
-            metric              = "opentelemetry_allocator_http_duration_seconds"
             query_name          = "a"
-            timeseries_operator = "delta"
-
-            group_by {
-                aggregation_method = "sum"
-                keys               = [
-                    "path",
-                ]
-            }
+            tql                 = <<-EOT
+                metric opentelemetry_allocator_http_duration_seconds
+                | delta 5m
+                | group_by [path], sum
+                | point percentile(value, 50.0), percentile(value, 95.0), percentile(value, 99.0)
+            EOT
         }
     }
     chart {


### PR DESCRIPTION
Fixes the following dashboards:
* `otel-collector-kubeletstatsreceiver-dashboard`
* `otel-collector-dashboard`
* `otel-target-allocator-dashboard`

Also updates our provider to the most recent version to utilize improved TQL support.