### PR TITLE
Doc Patch: Update Readme.md kubectl get resources command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a Terraform module for deploying pre-defined set of OpenTelemetry Integr
 ## Pre-requisites
 
 * Lightstep account and API Key with `member` permissons.
+    * You can obtain the API key from https://app.lightstep.com/<your-project-name>/account/api-keys
 * Terraform v1.0+
 
 

--- a/collector-dashboards/otel-collector-kubernetes-dashboard/README.md
+++ b/collector-dashboards/otel-collector-kubernetes-dashboard/README.md
@@ -13,7 +13,7 @@ Visit Lightstep to [Learn how to send telemetry from an OpenTelemetry Collector 
 
 1. Identify which Kubernetes workloads you would like to monitor.
     ```bash
-    % kubectl get deployment,daemonset,statefulset -A | awk ‘{print $1 $2}’
+    % kubectl get deployment,daemonset,statefulset -A | awk '{print $1 $2}'
     % kubectl get deployment,daemonset,statefulset -A -o jsonpath='{range .items[*]}namespace:{@.metadata.namespace} workload:{@.metadata.name}{"\n"}{end}'
     ```
 1. Create a module in your `.tf` file for the Kubernetes dashbaords.


### PR DESCRIPTION
Change `kubectl get deployment,daemonset,statefulset -A | awk ‘{print $1 $2}’` to `kubectl get deployment,daemonset,statefulset -A | awk '{print $1 $2}'`

Note the smart quotes (‘’ vs '')

Was leading to the following output when run: 

```
kubectl get deployment,daemonset,statefulset -A | awk ‘{print $1 $2}’     
awk: syntax error at source line 1
 context is
	 >>> � <<<
	missing }
awk: bailing out at source line 1

```