### PR TITLE
Update pod owner regex to remove wacky string

### DIFF
--- a/collector-dashboards/otel-collector-kubernetes-dashboard/workload.tf
+++ b/collector-dashboards/otel-collector-kubernetes-dashboard/workload.tf
@@ -1,5 +1,5 @@
 locals {
-  pod_owner_regex = "(-[bcdfghjklmnpqrstvwxz2456789]{3}[bcdfghjklmnpqrstvwxz2456789]{3}[bcdfghjklmnpqrstvwxz2456789]{4})?$"
+  pod_owner_regex = ".*"
 }
 
 


### PR DESCRIPTION
We don't need to use this strange string anymore.