### PR TITLE
bump squid version

### DIFF
--- a/collector-dashboards/otel-collector-squid-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-squid-dashboard/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.70.10"
+      version = "~> 1.76.0"
     }
   }
   required_version = ">= v1.0.11"


### PR DESCRIPTION
bumps the provider version ins squid dashboard to 1.76.0