### PR TITLE
Added vars for k8s dashboards

### DIFF
--- a/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-kubelet-prom-dashboard/main.tf
@@ -23,7 +23,7 @@ resource "lightstep_dashboard" "k8s_kubelet_dashboard" {
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_node_name | latest | group_by [], sum
+metric kubelet_node_name | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -39,7 +39,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_running_pods | latest | group_by [], sum
+metric kubelet_running_pods | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -55,7 +55,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_running_containers | latest | group_by [], sum
+metric kubelet_running_containers | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -71,7 +71,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric volume_manager_total_volumes | latest | group_by [], sum
+metric volume_manager_total_volumes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -87,7 +87,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric volume_manager_total_volumes | latest | group_by [], sum
+metric volume_manager_total_volumes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -103,7 +103,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_runtime_operations_total | rate | group_by ["operation_type"], sum
+metric kubelet_runtime_operations_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by ["operation_type"], sum
 EOT
     }
 
@@ -119,14 +119,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_runtime_operations_errors_total | rate | group_by [], sum
+metric kubelet_runtime_operations_errors_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Operation duration (p99)"
+    name = "Operation Duration (p99)"
     rank = "7"
     type = "timeseries"
 
@@ -135,7 +135,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_runtime_operations_duration_seconds | delta | group_by ["instance", "operation_type"], sum
+metric kubelet_runtime_operations_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["instance", "operation_type"], sum | point percentile(value, 99.0)
 EOT
     }
 
@@ -151,7 +151,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_pod_worker_duration_seconds | delta | group_by ["service"], sum
+metric kubelet_pod_worker_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["service"], sum | point percentile(value, 95.0)
 EOT
     }
 
@@ -160,7 +160,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_pod_start_duration_seconds | delta | group_by [], sum
+metric kubelet_pod_start_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by [], sum | point percentile(value, 95.0)
 EOT
     }
 
@@ -176,14 +176,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric storage_operation_duration_seconds | delta | group_by ["instance", "operation_name", "volume_plugin"], sum
+metric storage_operation_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["instance", "operation_name", "volume_plugin"], sum | point percentile(value, 99.0)
 EOT
     }
 
   }
 
   chart {
-    name = "Cgroup manager duration seconds (p99)"
+    name = "Cgroup Manager Duration Seconds (p99)"
     rank = "10"
     type = "timeseries"
 
@@ -192,14 +192,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_cgroup_manager_duration_seconds | delta | group_by ["instance", "operation_type"], sum
+metric kubelet_cgroup_manager_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["instance", "operation_type"], sum | point percentile(value, 99.0)
 EOT
     }
 
   }
 
   chart {
-    name = "PLEG relist interval (p99)"
+    name = "PLEG Relist Interval (p99)"
     rank = "11"
     type = "timeseries"
 
@@ -208,14 +208,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_pleg_relist_interval_seconds | delta | group_by ["instance"], sum
+metric kubelet_pleg_relist_interval_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["instance"], sum | point percentile(value, 99.0)
 EOT
     }
 
   }
 
   chart {
-    name = "PLEG relist duration (p99)"
+    name = "PLEG Relist Duration (p99)"
     rank = "12"
     type = "timeseries"
 
@@ -224,7 +224,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kubelet_pleg_relist_duration_seconds | delta | group_by ["instance"], sum
+metric kubelet_pleg_relist_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["instance"], sum | point percentile(value, 99.0)
 EOT
     }
 
@@ -240,7 +240,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric rest_client_requests_total | rate | group_by [], sum
+metric rest_client_requests_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 EOT
     }
 
@@ -249,7 +249,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric rest_client_requests_total | rate | group_by [], sum
+metric rest_client_requests_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 EOT
     }
 
@@ -258,14 +258,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric rest_client_requests_total | rate | group_by [], sum
+metric rest_client_requests_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Request duration (p99)"
+    name = "Request Duration (p99)"
     rank = "14"
     type = "timeseries"
 
@@ -274,7 +274,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric rest_client_request_duration_seconds | delta | group_by ["verb"], sum
+metric rest_client_request_duration_seconds | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["verb"], sum | point percentile(value, 99.0)
 EOT
     }
 
@@ -290,7 +290,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric process_resident_memory_bytes | latest | group_by [], sum
+metric process_resident_memory_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by [], sum
 EOT
     }
 
@@ -306,7 +306,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric process_cpu_seconds_total | rate | group_by ["instance"], mean
+metric process_cpu_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by ["instance"], mean
 EOT
     }
 
@@ -322,10 +322,20 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric go_goroutines | latest | group_by ["instance"], mean
+metric go_goroutines | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by ["instance"], mean
 EOT
     }
 
   }
 
+  template_variable {
+    name                     = "net_host_name"
+    default_values           = []
+    suggestion_attribute_key = "net.host.name"
+  }
+  template_variable {
+    name                     = "service_name"
+    default_values           = []
+    suggestion_attribute_key = "service.name"
+  }
 }

--- a/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-node-exporter-prom-dashboard/main.tf
@@ -23,7 +23,7 @@ resource "lightstep_dashboard" "k8s_node_exporter_dashboard" {
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_load1 | reduce mean | group_by [], min
+metric node_load1 | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], min
 EOT
     }
 
@@ -32,7 +32,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_load5 | reduce mean | group_by [], min
+metric node_load5 | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], min
 EOT
     }
 
@@ -41,7 +41,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_load15 | reduce mean | group_by [], min
+metric node_load15 | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], min
 EOT
     }
 
@@ -50,7 +50,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_cpu_seconds_total | rate | group_by [], sum
+metric node_cpu_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 EOT
     }
 
@@ -67,8 +67,8 @@ EOT
       hidden       = false
       query_string = <<EOT
 with
-  a = metric node_cpu_seconds_total | rate | group_by ["cpu"], sum;
-  b = metric node_cpu_seconds_total | delta | group_by ["cpu"], count;
+  a = metric node_cpu_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by ["cpu"], sum;
+  b = metric node_cpu_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | delta | group_by ["cpu"], count;
 join (1 - (a / b)), a=0, b=0
 EOT
     }
@@ -86,8 +86,8 @@ EOT
       hidden       = false
       query_string = <<EOT
 with
-  a = metric node_memory_MemAvailable_bytes | reduce mean | group_by [], sum;
-  b = metric node_memory_MemTotal_bytes | reduce mean | group_by [], sum;
+  a = metric node_memory_MemAvailable_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum;
+  b = metric node_memory_MemTotal_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum;
 join (100 - ((a / b) * 100)), a=0, b=0
 EOT
     }
@@ -105,9 +105,9 @@ EOT
       hidden       = false
       query_string = <<EOT
 with
-  a = metric node_memory_MemTotal_bytes | reduce mean | group_by [], sum;
-  b = metric node_memory_Cached_bytes | reduce mean | group_by [], sum;
-  c = metric node_memory_MemFree_bytes | reduce mean | group_by [], sum;
+  a = metric node_memory_MemTotal_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum;
+  b = metric node_memory_Cached_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum;
+  c = metric node_memory_MemFree_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum;
 join ((a - c) - b), a=0, b=0, c=0
 EOT
     }
@@ -117,7 +117,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_memory_Buffers_bytes | reduce mean | group_by [], sum
+metric node_memory_Buffers_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | reduce mean | group_by [], sum
 
 EOT
     }
@@ -134,7 +134,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_read_bytes_total | rate | group_by [], sum
+metric node_disk_read_bytes_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -144,7 +144,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_written_bytes_total | rate | group_by [], sum
+metric node_disk_written_bytes_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -154,7 +154,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_io_time_seconds_total | rate | group_by [], sum
+metric node_disk_io_time_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -171,7 +171,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_io_time_seconds_total | rate | group_by [], sum
+metric node_disk_io_time_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -181,7 +181,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_discard_time_seconds_total | rate | group_by [], sum
+metric node_disk_discard_time_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -191,7 +191,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_disk_flush_requests_time_seconds_total | rate | group_by [], sum
+metric node_disk_flush_requests_time_seconds_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by [], sum
 
 EOT
     }
@@ -209,8 +209,8 @@ EOT
       hidden       = false
       query_string = <<EOT
 with
-  a = metric node_filesystem_size_bytes | latest | group_by ["mountpoint"], max;
-  b = metric node_filesystem_avail_bytes | latest | group_by ["mountpoint"], max;
+  a = metric node_filesystem_size_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by ["mountpoint"], max;
+  b = metric node_filesystem_avail_bytes | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | latest | group_by ["mountpoint"], max;
 join (1 - (b / a)), a=0, b=0
 EOT
     }
@@ -227,7 +227,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_network_receive_bytes_total | rate | group_by ["device"], mean
+metric node_network_receive_bytes_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by ["device"], mean
 EOT
     }
 
@@ -243,10 +243,20 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric node_network_transmit_bytes_total | rate | group_by ["device"], mean
+metric node_network_transmit_bytes_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name)) | rate | group_by ["device"], mean
 EOT
     }
 
   }
 
+  template_variable {
+    name                     = "net_host_name"
+    default_values           = []
+    suggestion_attribute_key = "net.host.name"
+  }
+  template_variable {
+    name                     = "service_name"
+    default_values           = []
+    suggestion_attribute_key = "service.name"
+  }
 }

--- a/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-k8s-pod-resources-prom-dashboard/main.tf
@@ -14,7 +14,7 @@ resource "lightstep_dashboard" "k8s_resources_pod_dashboard" {
   dashboard_description = "Monitor K8S Pod Resources with this overview dashboard."
 
   chart {
-    name = "CPU Usage - Seconds"
+    name = "Pods Containers Running"
     rank = "0"
     type = "timeseries"
 
@@ -23,7 +23,7 @@ resource "lightstep_dashboard" "k8s_resources_pod_dashboard" {
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric container_cpu_usage_seconds_total | rate | group_by ["container"], mean
+metric kube_pod_container_status_running | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | delta | group_by [], mean
 EOT
     }
 
@@ -39,7 +39,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kube_pod_container_resource_requests | latest | group_by [], sum
+metric kube_pod_container_resource_requests | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | latest | group_by [], sum
 EOT
     }
 
@@ -48,42 +48,7 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kube_pod_container_resource_limits | latest | group_by [], sum
-EOT
-    }
-
-  }
-
-  chart {
-    name = "CPU Throttling"
-    rank = "2"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "area"
-      hidden       = false
-      query_string = <<EOT
-with
-  a = metric container_cpu_cfs_throttled_periods_total | rate | group_by [], sum;
-  b = metric container_cpu_cfs_periods_total | rate | group_by [], sum;
-join (a / b), a=0, b=0
-EOT
-    }
-
-  }
-
-  chart {
-    name = "Memory Usage (WSS)- Bytes"
-    rank = "3"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-metric container_memory_working_set_bytes | latest | group_by ["container"], sum
+metric kube_pod_container_resource_limits | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | latest | group_by [], sum
 EOT
     }
 
@@ -91,6 +56,47 @@ EOT
 
   chart {
     name = "Memory Usage (WSS) - Limits/Requests"
+    rank = "2"
+    type = "timeseries"
+
+    query {
+      query_name   = "a"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric kube_pod_container_resource_requests | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | latest | group_by [], sum
+EOT
+    }
+
+    query {
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric kube_pod_container_resource_limits | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | latest | group_by [], sum
+EOT
+    }
+
+  }
+
+  chart {
+    name = "Restarts Containers Total"
+    rank = "3"
+    type = "timeseries"
+
+    query {
+      query_name   = "b"
+      display      = "line"
+      hidden       = false
+      query_string = <<EOT
+metric kube_pod_container_status_restarts_total | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | delta | group_by [], sum
+EOT
+    }
+
+  }
+
+  chart {
+    name = "Pod Start Time"
     rank = "4"
     type = "timeseries"
 
@@ -99,23 +105,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric kube_pod_container_resource_requests | latest | group_by [], sum
-EOT
-    }
-
-    query {
-      query_name   = "b"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-metric kube_pod_container_resource_limits | latest | group_by [], sum
+metric kube_pod_start_time | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod)) | delta | group_by [], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Memory Usage by Container"
+    name = "Pod Completiion Time"
     rank = "5"
     type = "timeseries"
 
@@ -124,14 +121,14 @@ EOT
       display      = "bar"
       hidden       = false
       query_string = <<EOT
-metric container_memory_working_set_bytes | latest | group_by ["container"], sum
+metric kube_pod_completion_time | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod)) | delta | group_by [], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Receive Bandwidth"
+    name = "Pods containers waiting"
     rank = "6"
     type = "timeseries"
 
@@ -140,14 +137,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric container_network_receive_bytes_total | rate | group_by ["pod"], sum
+metric kube_pod_container_status_waiting | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod) && (container == $container)) | delta | group_by ["pod"], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Transmit Bandwidth"
+    name = "Pods created"
     rank = "7"
     type = "timeseries"
 
@@ -156,14 +153,14 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric container_network_transmit_bytes_total | rate | group_by ["pod"], sum
+metric kube_pod_created | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod)) | delta | group_by [], sum
 EOT
     }
 
   }
 
   chart {
-    name = "Rate of Received Packets"
+    name = "Pods unschedulable "
     rank = "8"
     type = "timeseries"
 
@@ -172,134 +169,30 @@ EOT
       display      = "line"
       hidden       = false
       query_string = <<EOT
-metric container_network_receive_packets_total | rate | group_by ["pod"], sum
+metric kube_pod_status_unschedulable | filter ((service.name == $service_name) && (net.host.name == $net_host_name) && (pod == $pod)) | delta | group_by [], sum
 EOT
     }
 
   }
 
-  chart {
-    name = "Rate of Transmitted Packets"
-    rank = "9"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-metric container_network_transmit_packets_total | rate | group_by ["pod"], sum
-EOT
-    }
-
+  template_variable {
+    name                     = "net_host_name"
+    default_values           = []
+    suggestion_attribute_key = "net.host.name"
   }
-
-  chart {
-    name = "Rate of Received Packets Dropped"
-    rank = "10"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-metric container_network_receive_packets_dropped_total | rate | group_by ["pod"], sum
-EOT
-    }
-
+  template_variable {
+    name                     = "service_name"
+    default_values           = []
+    suggestion_attribute_key = "service.name"
   }
-
-  chart {
-    name = "Rate of Transmitted Packets Dropped"
-    rank = "11"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-metric container_network_transmit_packets_dropped_total | rate | group_by ["pod"], sum
-EOT
-    }
-
+  template_variable {
+    name                     = "pod"
+    default_values           = []
+    suggestion_attribute_key = "pod"
   }
-
-  chart {
-    name = "IOPS (Pods)"
-    rank = "12"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-with
-  a = metric container_fs_writes_total | rate | group_by ["pod"], sum;
-  b = metric container_fs_reads_total | rate | group_by ["pod"], sum;
-join (a + b), a=0, b=0
-EOT
-    }
-
+  template_variable {
+    name                     = "container"
+    default_values           = []
+    suggestion_attribute_key = "container"
   }
-
-  chart {
-    name = "ThroughPut (Pods)"
-    rank = "13"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-with
-  a = metric container_fs_writes_bytes_total | rate | group_by ["pod"], sum;
-  b = metric container_fs_reads_bytes_total | rate | group_by ["pod"], sum;
-join (a + b), a=0, b=0
-EOT
-    }
-
-  }
-
-  chart {
-    name = "IOPS (Containers)"
-    rank = "14"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-with
-  a = metric container_fs_writes_total | rate | group_by ["container"], sum;
-  b = metric container_fs_reads_total | rate | group_by ["container"], sum;
-join (a + b), a=0, b=0
-EOT
-    }
-
-  }
-
-  chart {
-    name = "ThroughPut (Containers)"
-    rank = "15"
-    type = "timeseries"
-
-    query {
-      query_name   = "a"
-      display      = "line"
-      hidden       = false
-      query_string = <<EOT
-with
-  a = metric container_fs_writes_bytes_total | rate | group_by ["container"], sum;
-  b = metric container_fs_reads_bytes_total | rate | group_by ["container"], sum;
-join (a + b), a=0, b=0
-EOT
-    }
-
-  }
-
 }


### PR DESCRIPTION
## Description
What does this PR do?
K8s dashboard
<img width="1677" alt="Screenshot 2023-05-17 at 4 19 08 PM" src="https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/4259308/65c47fb6-1e32-4c8b-8bf7-9e60673580c8">

<img width="1680" alt="Screenshot 2023-05-17 at 4 20 01 PM" src="https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/4259308/cdac95ab-0f63-408d-99ed-80f2577b2a2a">

<img width="1317" alt="Screenshot 2023-05-23 at 5 36 35 PM" src="https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/4259308/5c0e4e47-4f42-40e8-9409-54ecfb53db5b">



## PR checklist

Please confirm the following items:
- [X] At least one screenshot of the proposed dashboard is included in this PR. If you're proposing substantive changes to queries or new queries then please ensure your screenshot shows relevant data.
- [X] All chart names are in [Title case](https://en.wikipedia.org/wiki/Title_case).
- [X] All query names are lower case letters, beginning the first query of each chart as "a" and proceeding alphabetically ... "b", "c", etcetera.
