### PR TITLE
Ls 52947 new collector dashboard

### DIFF
--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -2,198 +2,1361 @@ terraform {
   required_providers {
     lightstep = {
       source  = "lightstep/lightstep"
-      version = "~> 1.79.0"
+      version = "~> 1.84.0"
     }
   }
   required_version = ">= v1.0.11"
 }
 
-locals {
-}
-
 resource "lightstep_dashboard" "otel_collector_dashboard" {
+  dashboard_name        = "OpenTelemetry Collectors running in Kubernetes"
   project_name          = var.lightstep_project
-  dashboard_name        = "OpenTelemetry Collector"
-  dashboard_description = "OTel Collector Dashboard"
+  dashboard_description = "A top down dashboard for your Opentelemetry Collector configuration on a kubernetes cluster."
 
   group {
     rank            = 0
-    title           = ""
-    visibility_type = "implicit"
+    title           = "Overview"
+    visibility_type = "explicit"
 
     chart {
-      name   = "Collector Up %"
-      type   = "timeseries"
-      rank   = 1
-      x_pos  = 0
-      y_pos  = 0
-      width  = 16
-      height = 8
+      name        = "Metric Points Overview"
+      description = "The rate in which metric points flow through the collector"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 6
+      width       = 16
+      height      = 8
 
       query {
-        query_name   = "a"
-        display      = "bar"
+        query_name   = "c"
+        display      = "line"
         hidden       = false
-        query_string = "metric otelcol_process_uptime | filter ((collector_name == $collector_name) && (service_name == $service_name)) | rate 1s | group_by [\"collector_name\", \"job\", \"service_instance_id\"], sum | * 100.00"
+        query_string = "metric otelcol_exporter_enqueue_failed_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
-    }
-    chart {
-      name   = "Data Points Accepted & Rejected"
-      type   = "timeseries"
-      rank   = 2
-      x_pos  = 16
-      y_pos  = 0
-      width  = 16
-      height = 8
-
       query {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_receiver_accepted_metric_points | filter (((receiver == $receiver) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"receiver\", \"collector_name\"], sum"
+        query_string = "metric otelcol_exporter_sent_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
       query {
         query_name   = "b"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_receiver_accepted_spans | filter (((receiver == $receiver) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"receiver\", \"collector_name\"], sum"
-      }
-      query {
-        query_name   = "c"
-        display      = "line"
-        hidden       = false
-        query_string = "metric otelcol_receiver_refused_metric_points | filter (((receiver == $receiver) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"receiver\", \"collector_name\"], sum"
+        query_string = "metric otelcol_processor_dropped_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
       query {
         query_name   = "d"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_receiver_refused_spans | filter (((receiver == $receiver) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"receiver\", \"collector_name\"], sum"
+        query_string = "metric otelcol_processor_dropped_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
+      query {
+        query_name   = "e"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "f"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "g"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+
+      subtitle = ""
     }
     chart {
-      name   = "Processor Refused & Dropped"
-      type   = "timeseries"
-      rank   = 3
-      x_pos  = 32
-      y_pos  = 0
-      width  = 16
-      height = 8
+      name        = "Spans Overview"
+      description = "The rate in which spans flow through the collector"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 6
+      width       = 16
+      height      = 8
 
       query {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_processor_dropped_metric_points | filter (((processor == $processor) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"processor\", \"collector_name\"], sum"
-      }
-    }
-    chart {
-      name   = "Exporter Sent & Failed"
-      type   = "timeseries"
-      rank   = 4
-      x_pos  = 0
-      y_pos  = 8
-      width  = 16
-      height = 8
-
-      query {
-        query_name   = "a"
-        display      = "line"
-        hidden       = false
-        query_string = "metric otelcol_exporter_sent_metric_points | filter (((exporter == $exporter) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"exporter\", \"collector_name\"], sum"
+        query_string = "metric otelcol_exporter_enqueue_failed_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
       query {
         query_name   = "b"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_sent_spans | filter (((exporter == $exporter) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"exporter\", \"collector_name\"], sum"
+        query_string = "metric otelcol_exporter_enqueue_sent_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
       query {
         query_name   = "c"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_send_failed_metric_points | filter (((exporter == $exporter) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"exporter\", \"collector_name\"], sum"
+        query_string = "metric otelcol_processor_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
       query {
         query_name   = "d"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_send_failed_spans | filter (((exporter == $exporter) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"exporter\", \"collector_name\"], sum"
+        query_string = "metric otelcol_processor_refused_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
+      query {
+        query_name   = "e"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "f"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "g"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+
+      subtitle = ""
     }
     chart {
-      name   = "Batch Send Size"
-      type   = "timeseries"
-      rank   = 5
-      x_pos  = 16
-      y_pos  = 8
-      width  = 16
-      height = 8
+      name        = "Logs Overview"
+      description = "The rate in which logs flow through the collector"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 6
+      width       = 16
+      height      = 8
 
       query {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_processor_batch_batch_send_size | filter (((processor == $processor) && (collector_name == $collector_name)) && (service_name == $service_name)) | delta | group_by [\"processor\", \"collector_name\"], sum | point percentile(value, 99.0)"
+        query_string = "metric otelcol_exporter_enqueue_failed_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
       }
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_sent_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "c"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "d"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "e"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "f"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+      query {
+        query_name   = "g"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [], sum"
+      }
+
+      subtitle = ""
     }
     chart {
-      name   = "Exporter Queue Size"
-      type   = "timeseries"
-      rank   = 6
-      x_pos  = 32
-      y_pos  = 8
-      width  = 16
-      height = 8
+      name        = "Telemetry Refused By Receiver"
+      description = "The rate in which the receivers refuse metric points, spans, and log records due to errors"
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 0
+      y_pos       = 14
+      width       = 16
+      height      = 8
 
       query {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_queue_size | filter (((exporter == $exporter) && (collector_name == $collector_name)) && (service_name == $service_name)) | latest | group_by [\"exporter\", \"collector_name\"], sum"
+        query_string = "metric otelcol_receiver_refused_metric_points | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"receiver\"], sum"
       }
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_spans | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"receiver\"], sum"
+      }
+      query {
+        query_name   = "c"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_log_records | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"receiver\"], sum"
+      }
+
+      subtitle = ""
     }
     chart {
-      name   = "Hourly Active Time Series"
-      type   = "timeseries"
-      rank   = 7
-      x_pos  = 0
-      y_pos  = 16
-      width  = 16
-      height = 8
+      name        = "Telemetry Dropped And Refused By Processor"
+      description = "The rate in which metric points, spans, and log records are refused (rejected) or dropped by a processor"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 16
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+      query {
+        query_name   = "c"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+      query {
+        query_name   = "d"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+      query {
+        query_name   = "e"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+      query {
+        query_name   = "f"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Telemetry Failures By Exporter"
+      description = "The rate in which metric points, spans, and log records failed to be added to the collector queues for sending to a destination including CloudObs"
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"exporter\"], sum"
+      }
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_spans_total | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"exporter\"], sum"
+      }
+      query {
+        query_name   = "c"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"exporter\"], sum"
+      }
+      query {
+        query_name   = "d"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_metric_points_total | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"exporter\"], sum"
+      }
+      query {
+        query_name   = "e"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Total Pods Per Pool"
+      description = "Count of total Kubernetes pods per pool"
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 0
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "table"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter ((((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) && (\"service.name\" =~ \".*collector\")) | latest | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Total Pods Per Pool"
+      description = "Count of total Kubernetes pods per pool"
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 16
+      y_pos       = 22
+      width       = 16
+      height      = 8
 
       query {
         query_name   = "a"
         display      = "bar"
         hidden       = false
-        query_string = "metric lightstep.hourly_active_time_series\n| delta 1h\n| group_by [service.name], sum\n"
+        query_string = "metric k8s.pod.phase | filter ((((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) && (\"service.name\" =~ \".*collector\")) | latest 30s | group_by [\"service.name\"], count_nonzero"
       }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Pods in an Unhealthy Phase"
+      description = "Count of pods in the Failed or Unknown phase. If the chart has \"No data reported\", this likely means there has not been a pod in an unhealthy phase so far."
+      type        = "timeseries"
+      rank        = 8
+      x_pos       = 32
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "b"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 4 || value == 5 | latest | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "About this dashboard"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 6
+      text   = "This dashboard monitors the health of your OpenTelemetry Collectors that are running in Kubernetes. For more on Collectors, see https://docs.lightstep.com/docs/collector-home-page\n\nUse template variables to filter to collector pools and individual collector instances. Filter to a specific collector pool with the `$service.name` template variable. Collector pools running in k8s have a service name that ends with \"collector\"\n\nIf the charts indicate \"No Data Reported\" you may not be sending metrics for that chart."
+    }
+  }
+  group {
+    rank            = 1
+    title           = "Receivers"
+    visibility_type = "explicit"
+
+    chart {
+      name        = "Rate of Accepted Metric Points"
+      description = "Rate of metrics that were successfully reported to collectors vs refused by the collector"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"receiver\", \"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Spans"
+      description = "Rate of spans successfully pushed into the pipeline"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Log Records"
+      description = "Rate of log records successfully pushed into the pipeline"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Refused Metric Points"
+      description = "Rate of metric points that were not pushed into the pipeline"
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 0
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_metric_points | filter (((((\"service.name\" == $service_name) && (\"k8s.namespace.name\" == $namespace)) && (\"k8s.pod.name\" == $pod)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) | rate | group_by [\"receiver\", \"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Refused Spans"
+      description = "Rate of spans that could not be pushed into the pipeline"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 16
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Log Records Refused"
+      description = "Rate of log records that could not be pushed into the pipeline"
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_receiver_refused_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Scraped Metric Points"
+      description = "Rate of Metric Points Successfully Scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 0
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_scraper_scraped_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Errored Scraper Metric Points"
+      description = "Rate of metric points that were unable to be scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 16
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_scraper_errored_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"receiver\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Metric Points Scrape Error Rate [%]"
+      description = "The error rate of scraping metric points per collector pool. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      type        = "timeseries"
+      rank        = 8
+      x_pos       = 32
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "with\n  errors = metric otelcol_scraper_errored_metric_points | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | rate | group_by [\"service.name\"], sum;\n  successes = metric otelcol_scraper_scraped_metric_points | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | rate | group_by [\"service.name\"], sum;\njoin errors * 100.0 / (errors + successes), errors=0, successes=1"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "About This Section"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 6
+      text   = "Monitor the state of your OpenTelemetry Receivers (https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)\n\nSome receivers like the _hostmetrics_ and _prometheus_ receivers actively obtain telemetry data to place in the collection pipeline. The prometheus receiver can hit scaling issues if there are, say, thousands of prometheus endpoints to scrape. For guidance on scaling and sharding scrapers, see https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers\n\nFor all other information on scaling the receiver, see https://opentelemetry.io/docs/collector/scaling/#how-to-scale"
+    }
+  }
+  group {
+    rank            = 2
+    title           = "Processors"
+    visibility_type = "explicit"
+
+    chart {
+      name        = "Dropped Metric Points"
+      description = "Number of metric points that were dropped"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Dropped Spans"
+      description = "Number of metric points that were dropped"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Dropped Logs Records"
+      description = "Number of Logs that were dropped"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 6
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_dropped_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Metric Points"
+      description = "Number of metric points successfully pushed into the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 0
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Spans"
+      description = "Number of spans successfully pushed into the next component in the pipeline"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 16
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Log Records"
+      description = "Number of logs successfully pushed into the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Refused Metric Points"
+      description = "Number of metric points that were rejected by the next component in the pipeline"
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 0
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_metric_points | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.pod.name\" == $pod)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"service_name\" == $service_name)) && (\"k8s.cluster.name\" == $cluster)) | rate | group_by [], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Refused Spans"
+      description = "Number of Spans that were rejected by the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 16
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"processor\", \"$service_name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "99% Processor Batch Send Size"
+      description = "Distribution of batch send queue size per processor and collector pool in the 99th percentile"
+      type        = "timeseries"
+      rank        = 8
+      x_pos       = 0
+      y_pos       = 30
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_batch_batch_send_size | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter \"service.name\" == $service_name | delta | group_by [\"processor\", \"service.name\"], distribution | point percentile(value, 99.0)"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Refused Log Records"
+      description = "Number of log records that were rejected by the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 10
+      x_pos       = 32
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_log_records | filter (((((\"service.name\" == $service_name) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "About This Section"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 6
+      text   = "Processors are optional components that run on data between being received and being exported. If your collectors do not include any processors, these charts will be empty.\n\nIn the case of memory_limiter implementations, new data will be blocked from passing through the pipeline by the memory_limiter, and show up in the Refused Spans chart. For more information:  https://opentelemetry.io/docs/collector/scaling/#when-to-scale \n\nFor more information on processors: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md"
+    }
+  }
+  group {
+    rank            = 3
+    title           = "Exporters"
+    visibility_type = "explicit"
+
+    chart {
+      name        = "Sent Metric Points"
+      description = "Number of metric points sent to the destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 7
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_sent_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed Spans"
+      description = "Number of spans in failed attempts to send to destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 15
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Sent Log Records"
+      description = "Number of log records successfully sent to destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 7
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_sent_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed Metric Points"
+      description = "Number of metric points that failed to be sent to destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 0
+      y_pos       = 15
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Sent Spans"
+      description = "Number of spans successfully sent to destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 16
+      y_pos       = 7
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_sent_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed Log Records"
+      description = "Number of log records in failed attempts to send to destination, including Cloud Observability"
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 15
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_enqueue_failed_to_send_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Collector Exporter Queue Size"
+      description = "Current size of the retry queue"
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 0
+      y_pos       = 23
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_queue_size | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | latest | group_by [\"exporter\", \"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Queue Capacity (in batches)"
+      description = "Indicates the capacity of the retry queue (in batches) per collector pool"
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 16
+      y_pos       = 23
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_queue_capacity | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | latest 1m | group_by [\"service.name\", \"exporter\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Queue Usage [%]"
+      description = "Indicates the usage of the in-memory telemetry exporter queue, relative to queue capacity per collector pool. If the queue usage reaches 100% capacity, the collector will reject data. The collector queues telemetry while waiting for a worker to be ready to send the telemetry"
+      type        = "timeseries"
+      rank        = 8
+      x_pos       = 32
+      y_pos       = 23
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "with\n  capacity = metric otelcol_exporter_queue_capacity | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | latest 1m | group_by [\"service.name\", \"exporter\"], sum;\n  size = metric otelcol_exporter_queue_size | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | latest 1m | group_by [\"service.name\", \"exporter\"], sum;\njoin size * 100.0 / capacity, capacity=1, size=0"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "About This Section"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 7
+      text   = "Monitor the Queue Usage chart to ensure data isn't piling up. The Collector will queue data in memory while waiting for a worker to become available to send the data. If there aren’t enough workers or the backend is too slow, data starts piling up in the queue. \n\nAn increase in the Failed Spans chart indicates that sending data to the backend failed permanently and further triage is needed.\n\nFor more information on scaling refer to the OpenTelemetry documentation: https://opentelemetry.io/docs/collector/scaling/#how-to-scale\n\nFor more information on exporters: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md"
+    }
+  }
+  group {
+    rank            = 4
+    title           = "Resource Usage"
+    visibility_type = "explicit"
+
+    chart {
+      name        = "99% CPU Usage [%]"
+      description = "99th percentile CPU usage of the pods in each Collector pool"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 5
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.pod.cpu.utilization | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], distribution | point percentile(value, 99.0)"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Memory Usage [%]"
+      description = "Percent of memory used relative to available per collector pool"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 5
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "with\n  usage = metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\n  available = metric k8s.pod.memory.available | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\njoin usage / available * 100, usage=0, available=1"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Network Ingress Bandwidth (bytes/sec)"
+      description = "The bandwidth of network traffic received by each collector pool"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 5
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.pod.network.io | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter \"service.name\" == $service_name && \"service.name\" =~ \".*collector\" && \"direction\" == \"receive\" | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Average CPU Usage [%]"
+      description = "Average (arithmetic mean) of CPU usage of the pods in each Collector pool"
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 0
+      y_pos       = 13
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.pod.cpu.utilization | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], distribution | point percentile(value, 50.0)"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Memory Used Per Pool"
+      description = "Distribution of memory used by the pods in each Collector pool"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 16
+      y_pos       = 13
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "heatmap"
+        hidden       = false
+        query_string = "metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [\"service.name\"], distribution"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Network Egress Bandwidth (bytes/sec)"
+      description = "The bandwidth of network traffic transmitted by each collector pool"
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 13
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.pod.network.io | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter \"service.name\" == $service_name && \"service.name\" =~ \".*collector\" && \"direction\" == \"transmit\" | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "Collector Resource Usage"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 5
+      text   = "Examine CPU and memory utilization, if you see extended CPU or memory utilization coinciding with container restarts it may indicate a scaling issue. Other symptoms may include dropped telemetry. \n\nIf data is frequently refused due to memory limits, consider scaling up. For more information on scaling see: https://docs.lightstep.com/docs/kubernetes-collector-tracing-scaling "
+    }
+  }
+  group {
+    rank            = 5
+    title           = "Pod Lifecycle"
+    visibility_type = "explicit"
+
+    chart {
+      name        = "Uptime per pod [seconds]"
+      description = "The uptime of each collector pod, represented in seconds"
+      type        = "timeseries"
+      rank        = 0
+      x_pos       = 0
+      y_pos       = 4
+      width       = 16
+      height      = 16
+
+      query {
+        query_name = "a"
+        display    = "table"
+
+        display_type_options {
+          sort_by        = ""
+          sort_direction = "desc"
+          y_axis_min     = 0
+          y_axis_max     = 0
+          y_axis_scale   = ""
+        }
+        hidden       = false
+        query_string = "metric otelcol_process_uptime | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | delta | group_by [\"k8s.pod.name\"], max"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Running"
+      description = "Count of collector pods in the Running phase"
+      type        = "timeseries"
+      rank        = 1
+      x_pos       = 16
+      y_pos       = 4
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 2 | latest 1m | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Pending"
+      description = "Count of collector pods in the Pending phase"
+      type        = "timeseries"
+      rank        = 2
+      x_pos       = 32
+      y_pos       = 4
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name| filter service.name =~ \".*collector\" | point_filter value == 1 | latest 1m | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Succeeded"
+      description = "Count of collector pods in the Succeeded phase"
+      type        = "timeseries"
+      rank        = 3
+      x_pos       = 16
+      y_pos       = 12
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 3 | latest 1m | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed"
+      description = "Count of collector pods in the Failed phase"
+      type        = "timeseries"
+      rank        = 4
+      x_pos       = 32
+      y_pos       = 12
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 4 | latest 1m | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Collector pod start time"
+      description = "The start time of each collector pod represented in UTC"
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 0
+      y_pos       = 20
+      width       = 16
+      height      = 16
+
+      query {
+        query_name = "a"
+        display    = "table"
+
+        display_type_options {
+          sort_by        = "k8s.pod.start_time"
+          sort_direction = "desc"
+          y_axis_min     = 0
+          y_axis_max     = 0
+          y_axis_scale   = ""
+        }
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | point_filter value == 2 | group_by [\"k8s.pod.start_time\", \"k8s.pod.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Unknown"
+      description = "Count of collector pods in the Unknown phase"
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 16
+      y_pos       = 20
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "bar"
+        hidden       = false
+        query_string = "metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 5 | latest 1m | group_by [\"service.name\"], count_nonzero"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Collectors by pod phase"
+      description = "The overall breakdown in percent of collector pods in terms of phase"
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 32
+      y_pos       = 20
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "area"
+        hidden       = false
+        query_string = "with\n  pending = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 1 | latest 1m | group_by [], count_nonzero;\n  total = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [], count_nonzero;\njoin pending * 100.0 / total, pending=0, total=1"
+      }
+      query {
+        query_name   = "b"
+        display      = "area"
+        hidden       = false
+        query_string = "with\n  running = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 2 | latest 1m | group_by [], count_nonzero;\n  total = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [], count_nonzero;\njoin running * 100.0 / total, running=0, total=1"
+      }
+      query {
+        query_name   = "c"
+        display      = "area"
+        hidden       = false
+        query_string = "with\n  success = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 3 | latest 1m | group_by [], count_nonzero;\n  total = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [], count_nonzero;\njoin success * 100.0 / total, success=0, total=1"
+      }
+      query {
+        query_name   = "d"
+        display      = "area"
+        hidden       = false
+        query_string = "with\n  failed = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 4 | latest 1m | group_by [], count_nonzero;\n  total = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [], count_nonzero;\njoin failed * 100.0 / total, failed=0, total=1"
+      }
+      query {
+        query_name   = "e"
+        display      = "area"
+        hidden       = false
+        query_string = "with\n  unknown = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | point_filter value == 5 | latest 1m | group_by [], count_nonzero;\n  total = metric k8s.pod.phase | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [], count_nonzero;\njoin unknown * 100.0 / total, unknown=0, total=1"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Container Restarts per pool"
+      description = "Container restarts per collector pool"
+      type        = "timeseries"
+      rank        = 8
+      x_pos       = 16
+      y_pos       = 28
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.container.restarts | filter ((((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) && (\"service.name\" =~ \".*collector\")) | delta 1m | group_by [\"service.name\"], sum | point (((value +(abs (value)))/2))"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Container Restarts per pod"
+      description = "Restarts by pod and container"
+      type        = "timeseries"
+      rank        = 9
+      x_pos       = 32
+      y_pos       = 28
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric k8s.container.restarts | filter ((((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) && (\"service.name\" =~ \".*collector\")) | delta 1m | group_by [\"service.name\", \"k8s.pod.name\", \"k8s.container.name\"], sum | point (((value +(abs (value)))/2))"
+      }
+
+      subtitle = ""
+    }
+
+    text_panel {
+      name   = "Kubernetes pod phases"
+      x_pos  = 0
+      y_pos  = 0
+      width  = 48
+      height = 4
+      text   = "This section tracks the k8s pod phases for the collector pods in each pool. Collector pods should be in the Running phase at their steady state, but will be Pending when the pod is coming up. For more details about kubernetes pod phases, see https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
     }
   }
 
+  template_variable {
+    name                     = "namespace"
+    default_values           = []
+    suggestion_attribute_key = "k8s.namespace.name"
+  }
+  template_variable {
+    name                     = "pod_uid"
+    default_values           = []
+    suggestion_attribute_key = "k8s.pod.uid"
+  }
+  template_variable {
+    name                     = "pod"
+    default_values           = []
+    suggestion_attribute_key = "k8s.pod.name"
+  }
+  template_variable {
+    name                     = "cluster"
+    default_values           = []
+    suggestion_attribute_key = "k8s.cluster.name"
+  }
   template_variable {
     name                     = "service_name"
     default_values           = []
-    suggestion_attribute_key = "service_name"
+    suggestion_attribute_key = "service.name"
   }
-  template_variable {
-    name                     = "collector_name"
-    default_values           = []
-    suggestion_attribute_key = "collector_name"
+
+  label {
+    key   = ""
+    value = "kubernetes"
   }
-  template_variable {
-    name                     = "processor"
-    default_values           = []
-    suggestion_attribute_key = "processor"
-  }
-  template_variable {
-    name                     = "receiver"
-    default_values           = []
-    suggestion_attribute_key = "receiver"
-  }
-  template_variable {
-    name                     = "exporter"
-    default_values           = []
-    suggestion_attribute_key = "exporter"
+  label {
+    key   = ""
+    value = "otel"
   }
 }

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -1403,4 +1403,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     key   = ""
     value = "otel"
   }
+  label {
+    key   = ""
+    value = "recommended"
+  }
 }

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -308,7 +308,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Total Pods Per Pool"
-      description = "Count of total Kubernetes pods per pool"
+      description = "Count Of total Kubernetes pods per pool"
       type        = "timeseries"
       rank        = 6
       x_pos       = 0
@@ -327,7 +327,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Total Pods Per Pool"
-      description = "Count of total Kubernetes pods per pool"
+      description = "Count Of total Kubernetes pods per pool"
       type        = "timeseries"
       rank        = 7
       x_pos       = 16
@@ -345,8 +345,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Pods in an Unhealthy Phase"
-      description = "Count of pods in the Failed or Unknown phase. If the chart has \"No data reported\", this likely means there has not been a pod in an unhealthy phase so far."
+      name        = "Pods In An Unhealthy Phase"
+      description = "Count Of pods in the Failed or Unknown phase. If the chart has \"No data reported\", this likely means there has not been a pod in an unhealthy phase so far."
       type        = "timeseries"
       rank        = 8
       x_pos       = 32
@@ -370,7 +370,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "This dashboard monitors the health of your [OpenTelemetry Collectors](https://opentelemetry.io/docs/collector/) that are running in Kubernetes. For more on Collectors, see https://docs.lightstep.com/docs/collector-home-page\n\nUse template variables to filter to collector pools and individual collector instances. Filter to a specific collector pool with the `$service.name` template variable. Collector pools running in k8s have a service name that ends with \"collector\"\n\nIf the charts indicate \"No Data Reported\" you may not be sending metrics for that chart."
+      text   = "This dashboard monitors the health Of your [OpenTelemetry Collectors](https://opentelemetry.io/docs/collector/) that are running in Kubernetes. For more on Collectors, see https://docs.lightstep.com/docs/collector-home-page\n\nUse template variables to filter to collector pools and individual collector instances. Filter to a specific collector pool with the `$service.name` template variable. Collector pools running in k8s have a service name that ends with \"collector\"\n\nIf the charts indicate \"No Data Reported\" you may not be sending metrics for that chart."
     }
   }
   group {
@@ -379,8 +379,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     visibility_type = "explicit"
 
     chart {
-      name        = "Rate of Accepted Metric Points"
-      description = "Rate of metrics that were successfully reported to collectors vs refused by the collector"
+      name        = "Rate Of Accepted Metric Points"
+      description = "Rate Of metrics that were successfully reported to collectors vs refused by the collector"
       type        = "timeseries"
       rank        = 0
       x_pos       = 0
@@ -398,8 +398,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Spans"
-      description = "Rate of spans successfully pushed into the pipeline"
+      name        = "Rate Of Accepted Spans"
+      description = "Rate Of spans successfully pushed into the pipeline"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
@@ -417,8 +417,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Log Records"
-      description = "Rate of log records successfully pushed into the pipeline"
+      name        = "Rate Of Accepted Log Records"
+      description = "Rate Of log records successfully pushed into the pipeline"
       type        = "timeseries"
       rank        = 2
       x_pos       = 32
@@ -436,8 +436,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Metric Points"
-      description = "Rate of metric points that were not pushed into the pipeline"
+      name        = "Rate Of Refused Metric Points"
+      description = "Rate Of metric points that were not pushed into the pipeline"
       type        = "timeseries"
       rank        = 3
       x_pos       = 0
@@ -455,8 +455,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Spans"
-      description = "Rate of spans that could not be pushed into the pipeline"
+      name        = "Rate Of Refused Spans"
+      description = "Rate Of spans that could not be pushed into the pipeline"
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
@@ -474,8 +474,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Log Records Refused"
-      description = "Rate of log records that could not be pushed into the pipeline"
+      name        = "Rate Of Log Records Refused"
+      description = "Rate Of log records that could not be pushed into the pipeline"
       type        = "timeseries"
       rank        = 5
       x_pos       = 32
@@ -493,8 +493,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Scraped Metric Points"
-      description = "Rate of Metric Points Successfully Scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      name        = "Rate Of Scraped Metric Points"
+      description = "Rate Of Metric Points Successfully Scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
       type        = "timeseries"
       rank        = 6
       x_pos       = 0
@@ -512,8 +512,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Errored Scraper Metric Points"
-      description = "Rate of metric points that were unable to be scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      name        = "Rate Of Errored Scraper Metric Points"
+      description = "Rate Of metric points that were unable to be scraped. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
       type        = "timeseries"
       rank        = 7
       x_pos       = 16
@@ -532,7 +532,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Metric Points Scrape Error Rate [%]"
-      description = "The error rate of scraping metric points per collector pool. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
+      description = "The error rate Of scraping metric points per collector pool. These may include prometheus scraped metrics: https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers"
       type        = "timeseries"
       rank        = 8
       x_pos       = 32
@@ -556,7 +556,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "Monitor the state of your Collector [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md) that accept or scrape telemetry data for collection.\n\nSome receivers like the [_hostmetrics_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md) and [_prometheus_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md) receivers actively obtain telemetry data to place in the collection pipeline. The prometheus receiver can hit scaling issues if there are, say, thousands of prometheus endpoints to scrape. For guidance on scaling and sharding scrapers, see https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers\n\nFor all other information on scaling the receiver, see https://opentelemetry.io/docs/collector/scaling/#how-to-scale"
+      text   = "Monitor the state Of your Collector [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md) that accept or scrape telemetry data for collection.\n\nSome receivers like the [_hostmetrics_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md) and [_prometheus_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md) receivers actively obtain telemetry data to place in the collection pipeline. The prometheus receiver can hit scaling issues if there are, say, thousands Of prometheus endpoints to scrape. For guidance on scaling and sharding scrapers, see https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers\n\nFor all other information on scaling the receiver, see https://opentelemetry.io/docs/collector/scaling/#how-to-scale"
     }
   }
   group {
@@ -566,7 +566,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
     chart {
       name        = "Dropped Metric Points"
-      description = "Number of metric points that were dropped"
+      description = "Number Of metric points that were dropped"
       type        = "timeseries"
       rank        = 0
       x_pos       = 0
@@ -585,7 +585,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Dropped Spans"
-      description = "Number of metric points that were dropped"
+      description = "Number Of metric points that were dropped"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
@@ -604,7 +604,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Dropped Logs Records"
-      description = "Number of Logs that were dropped"
+      description = "Number Of Logs that were dropped"
       type        = "timeseries"
       rank        = 2
       x_pos       = 32
@@ -622,8 +622,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Metric Points"
-      description = "Number of metric points that were rejected by the next component in the pipeline"
+      name        = "Rate Of Refused Metric Points"
+      description = "Number Of metric points that were rejected by the next component in the pipeline"
       type        = "timeseries"
       rank        = 3
       x_pos       = 0
@@ -641,8 +641,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Spans"
-      description = "Number of Spans that were rejected by the next component in the pipeline."
+      name        = "Rate Of Refused Spans"
+      description = "Number Of Spans that were rejected by the next component in the pipeline."
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
@@ -660,8 +660,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Log Records"
-      description = "Number of log records that were rejected by the next component in the pipeline."
+      name        = "Rate Of Refused Log Records"
+      description = "Number Of log records that were rejected by the next component in the pipeline."
       type        = "timeseries"
       rank        = 5
       x_pos       = 32
@@ -679,8 +679,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Metric Points"
-      description = "Number of metric points successfully pushed into the next component in the pipeline."
+      name        = "Rate Of Accepted Metric Points"
+      description = "Number Of metric points successfully pushed into the next component in the pipeline."
       type        = "timeseries"
       rank        = 6
       x_pos       = 0
@@ -698,8 +698,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Spans"
-      description = "Number of spans successfully pushed into the next component in the pipeline"
+      name        = "Rate Of Accepted Spans"
+      description = "Number Of spans successfully pushed into the next component in the pipeline"
       type        = "timeseries"
       rank        = 7
       x_pos       = 16
@@ -717,8 +717,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Log Records"
-      description = "Number of logs successfully pushed into the next component in the pipeline."
+      name        = "Rate Of Accepted Log Records"
+      description = "Number Of logs successfully pushed into the next component in the pipeline."
       type        = "timeseries"
       rank        = 8
       x_pos       = 32
@@ -737,7 +737,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "99% Processor Batch Send Size"
-      description = " 99th percentile of the size of batches (in count of metric points, spans, or logs) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end of batch payloads in count of items that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
+      description = " 99th percentile Of the size Of batches (in count Of metric points, spans, or logs) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end Of batch payloads in count Of items that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
       type        = "timeseries"
       rank        = 9
       x_pos       = 0
@@ -756,7 +756,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "99% Processor Batch Send Size in Bytes"
-      description = "99th percentile of the size of batches (in bytes) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end of batch payloads in byte size that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
+      description = "99th percentile Of the size Of batches (in bytes) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end Of batch payloads in byte size that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
       type        = "timeseries"
       rank        = 10
       x_pos       = 16
@@ -777,7 +777,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       name        = "Batch Processor Triggers"
       description = "The [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md) is triggered to send a batch when it exceeds their target size or after a timeout, whichever happens first. This chart shows the balance between size and timeout triggers. Adjust the batch processor by configuring `send_batch_size`, `send_batch_max_size`, and `timeout`."
       type        = "timeseries"
-      rank        = 12
+      rank        = 11
       x_pos       = 32
       y_pos       = 30
       width       = 16
@@ -805,7 +805,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "Monitor the state of your Collector [Processors](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md) that operate on received telemetry before it is exported. Processors are optional components, and if your collectors do not include any processors, these charts will be empty.\n\nIn the case of the [_memory_limiter_](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md) processor, new telemetry data will be blocked from passing through the pipeline by the _memory_limiter_, and show up in the Refused Metric Points, Spans, or Log Records charts. If telemetry is regularly refused due to memory limits, you likely need to scale up your cluster.\n\nFor more information, see https://opentelemetry.io/docs/collector/scaling/#when-to-scale "
+      text   = "Monitor the state Of your Collector [Processors](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md) that operate on received telemetry before it is exported. Processors are optional components, and if your collectors do not include any processors, these charts will be empty.\n\nIn the case Of the [_memory_limiter_](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md) processor, new telemetry data will be blocked from passing through the pipeline by the _memory_limiter_, and show up in the Refused Metric Points, Spans, or Log Records charts. If telemetry is regularly refused due to memory limits, you likely need to scale up your cluster.\n\nFor more information, see https://opentelemetry.io/docs/collector/scaling/#when-to-scale "
     }
   }
   group {
@@ -815,11 +815,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
     chart {
       name        = "Sent Metric Points"
-      description = "Number of metric points sent to the destination, including Cloud Observability"
+      description = "Number Of metric points sent to the destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 0
       x_pos       = 0
-      y_pos       = 7
+      y_pos       = 5
       width       = 16
       height      = 8
 
@@ -834,11 +834,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Sent Spans"
-      description = "Number of spans successfully sent to destination, including Cloud Observability"
+      description = "Number Of spans successfully sent to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
-      y_pos       = 7
+      y_pos       = 5
       width       = 16
       height      = 8
 
@@ -853,11 +853,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Sent Log Records"
-      description = "Number of log records successfully sent to destination, including Cloud Observability"
+      description = "Number Of log records successfully sent to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 2
       x_pos       = 32
-      y_pos       = 7
+      y_pos       = 5
       width       = 16
       height      = 8
 
@@ -871,12 +871,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Failed Metric Points"
-      description = "Number of metric points that failed to be sent to destination, including Cloud Observability"
+      name        = "Failed Enqueue Metric Points"
+      description = "Number Of metric points that failed to be sent to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 3
       x_pos       = 0
-      y_pos       = 15
+      y_pos       = 13
       width       = 16
       height      = 8
 
@@ -890,12 +890,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Failed Spans"
-      description = "Number of spans in failed attempts to send to destination, including Cloud Observability"
+      name        = "Failed Enqueue Spans"
+      description = "Number Of spans in failed attempts to send to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
-      y_pos       = 15
+      y_pos       = 13
       width       = 16
       height      = 8
 
@@ -909,12 +909,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Failed Log Records"
-      description = "Number of log records in failed attempts to send to destination, including Cloud Observability"
+      name        = "Failed Enqueue Log Records"
+      description = "Number Of log records in failed attempts to send to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 5
       x_pos       = 32
-      y_pos       = 15
+      y_pos       = 13
       width       = 16
       height      = 8
 
@@ -929,11 +929,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Collector Exporter Queue Size"
-      description = "Current size of the retry queue"
+      description = "Current size Of the retry queue"
       type        = "timeseries"
       rank        = 6
       x_pos       = 0
-      y_pos       = 23
+      y_pos       = 29
       width       = 16
       height      = 8
 
@@ -948,11 +948,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Queue Capacity (in batches)"
-      description = "Indicates the capacity of the retry queue (in batches) per collector pool"
+      description = "Indicates the capacity Of the retry queue (in batches) per collector pool"
       type        = "timeseries"
       rank        = 7
       x_pos       = 16
-      y_pos       = 23
+      y_pos       = 29
       width       = 16
       height      = 8
 
@@ -967,11 +967,11 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Queue Usage [%]"
-      description = "Indicates the usage of the in-memory telemetry exporter queue, relative to queue capacity per collector pool. If the queue usage reaches 100% capacity, the collector will reject data. The collector queues telemetry while waiting for a worker to be ready to send the telemetry"
+      description = "Indicates the usage Of the in-memory telemetry exporter queue, relative to queue capacity per collector pool. If the queue usage reaches 100% capacity, the collector will reject data. The collector queues telemetry while waiting for a worker to be ready to send the telemetry"
       type        = "timeseries"
       rank        = 8
       x_pos       = 32
-      y_pos       = 23
+      y_pos       = 29
       width       = 16
       height      = 8
 
@@ -984,14 +984,71 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
       subtitle = ""
     }
+    chart {
+      name        = "Failed Spans"
+      description = "Indicates that the exporter is unable to export spans as expected"
+      type        = "timeseries"
+      rank        = 9
+      x_pos       = 16
+      y_pos       = 21
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_send_failed_spans | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.pod.name\" == $pod)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed Metric Points"
+      description = "Indicates that the exporter is unable to export metric points as expected"
+      type        = "timeseries"
+      rank        = 10
+      x_pos       = 0
+      y_pos       = 21
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_send_failed_metric_points | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.pod.name\" == $pod)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Failed Log Records"
+      description = "Indicates that the exporter is unable to export logs as expected"
+      type        = "timeseries"
+      rank        = 12
+      x_pos       = 32
+      y_pos       = 21
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_exporter_send_failed_log_records | filter (((((\"k8s.namespace.name\" == $namespace) && (\"k8s.pod.name\" == $pod)) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
 
     text_panel {
       name   = "About This Section"
       x_pos  = 0
       y_pos  = 0
       width  = 48
-      height = 7
-      text   = "Monitor the state of your Collector [Exporters](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md) that send telemetry to CloudObs and any other configured destinations.\n\nCheck the Queue Usage chart to ensure data isn't piling up. The collector will queue data in memory while waiting for a worker to become available to send the data. If there aren’t enough workers or the backend is too slow, data starts piling up in the queue. Increasing the queue size might alleviate pressure on the backend destination in this case.\n\nAn increase in the Failed Spans chart indicates that sending data to the backend failed permanently and further triage is needed.\n"
+      height = 5
+      text   = "Monitor the state Of your Collector [Exporters](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md) that send telemetry to CloudObs and any other configured destinations.\n\nCheck the Queue Usage chart to ensure data isn't piling up. The collector will queue data in memory while waiting for a worker to become available to send the data. If there aren’t enough workers or the backend is too slow, data starts piling up in the queue. Increasing the queue size might alleviate pressure on the backend destination in this case.\n\nAn increase in the Failed Spans, Metrics, Logs chart indicates that sending data to the backend failed permanently and further triage is needed.\n"
     }
   }
   group {
@@ -1001,7 +1058,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
     chart {
       name        = "99% CPU Usage [%]"
-      description = "99th percentile CPU usage of the pods in each Collector pool"
+      description = "99th percentile CPU usage Of the pods in each Collector pool"
       type        = "timeseries"
       rank        = 0
       x_pos       = 0
@@ -1020,7 +1077,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Memory Usage [%]"
-      description = "Percent of memory used relative to available per collector pool"
+      description = "Percent Of memory used relative to available per collector pool"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
@@ -1039,7 +1096,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Network Ingress Bandwidth (bytes/sec)"
-      description = "The bandwidth of network traffic received by each collector pool"
+      description = "The bandwidth Of network traffic received by each collector pool"
       type        = "timeseries"
       rank        = 2
       x_pos       = 32
@@ -1058,7 +1115,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Average CPU Usage [%]"
-      description = "Average (arithmetic mean) of CPU usage of the pods in each Collector pool"
+      description = "Average (arithmetic mean) Of CPU usage Of the pods in each Collector pool"
       type        = "timeseries"
       rank        = 3
       x_pos       = 0
@@ -1077,7 +1134,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "99% Memory Used Per Pool"
-      description = "99th percentile of memory used by the pods in each collector pool. This shows the upper end of memory usage across the collector pods in a pool in absolute terms."
+      description = "99th percentile Of memory used by the pods in each collector pool. This shows the upper end Of memory usage across the collector pods in a pool in absolute terms."
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
@@ -1096,7 +1153,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Network Egress Bandwidth (bytes/sec)"
-      description = "The bandwidth of network traffic transmitted by each collector pool"
+      description = "The bandwidth Of network traffic transmitted by each collector pool"
       type        = "timeseries"
       rank        = 5
       x_pos       = 32
@@ -1130,7 +1187,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
     chart {
       name        = "Uptime Per Pod [seconds]"
-      description = "The uptime of each collector pod, represented in seconds"
+      description = "The uptime Of each collector pod, represented in seconds"
       type        = "timeseries"
       rank        = 0
       x_pos       = 0
@@ -1157,7 +1214,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Running"
-      description = "Count of collector pods in the Running phase"
+      description = "Count Of collector pods in the Running phase"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
@@ -1176,7 +1233,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Pending"
-      description = "Count of collector pods in the Pending phase"
+      description = "Count Of collector pods in the Pending phase"
       type        = "timeseries"
       rank        = 2
       x_pos       = 32
@@ -1195,7 +1252,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Succeeded"
-      description = "Count of collector pods in the Succeeded phase"
+      description = "Count Of collector pods in the Succeeded phase"
       type        = "timeseries"
       rank        = 3
       x_pos       = 16
@@ -1214,7 +1271,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Failed"
-      description = "Count of collector pods in the Failed phase"
+      description = "Count Of collector pods in the Failed phase"
       type        = "timeseries"
       rank        = 4
       x_pos       = 32
@@ -1232,8 +1289,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Collector pod start time"
-      description = "The start time of each collector pod represented in UTC"
+      name        = "Collector Pod Start Time"
+      description = "The start time Of each collector pod represented in UTC"
       type        = "timeseries"
       rank        = 5
       x_pos       = 0
@@ -1260,7 +1317,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
     chart {
       name        = "Unknown"
-      description = "Count of collector pods in the Unknown phase"
+      description = "Count Of collector pods in the Unknown phase"
       type        = "timeseries"
       rank        = 6
       x_pos       = 16
@@ -1278,8 +1335,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Collectors by Pod Phase"
-      description = "The overall breakdown in percent of collector pods in terms of phase"
+      name        = "Collectors By Pod Phase"
+      description = "The overall breakdown in percent Of collector pods in terms Of phase"
       type        = "timeseries"
       rank        = 7
       x_pos       = 32
@@ -1360,7 +1417,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
 
     text_panel {
-      name   = "Kubernetes Pod Phases"
+      name   = "Kubernetes pod phases"
       x_pos  = 0
       y_pos  = 0
       width  = 48
@@ -1397,14 +1454,14 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
   label {
     key   = ""
+    value = "recommended"
+  }
+  label {
+    key   = ""
     value = "kubernetes"
   }
   label {
     key   = ""
     value = "otel"
-  }
-  label {
-    key   = ""
-    value = "recommended"
   }
 }

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -1129,7 +1129,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     visibility_type = "explicit"
 
     chart {
-      name        = "Uptime per pod [seconds]"
+      name        = "Uptime Per Pod [seconds]"
       description = "The uptime of each collector pod, represented in seconds"
       type        = "timeseries"
       rank        = 0
@@ -1278,7 +1278,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Collectors by pod phase"
+      name        = "Collectors by Pod Phase"
       description = "The overall breakdown in percent of collector pods in terms of phase"
       type        = "timeseries"
       rank        = 7
@@ -1321,7 +1321,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Container Restarts per pool"
+      name        = "Container Restarts Per Pool"
       description = "Container restarts per collector pool"
       type        = "timeseries"
       rank        = 8
@@ -1340,7 +1340,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Container Restarts per pod"
+      name        = "Container Restarts Per Pod"
       description = "Restarts by pod and container"
       type        = "timeseries"
       rank        = 9
@@ -1360,7 +1360,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
     }
 
     text_panel {
-      name   = "Kubernetes pod phases"
+      name   = "Kubernetes Pod Phases"
       x_pos  = 0
       y_pos  = 0
       width  = 48

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -370,7 +370,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "This dashboard monitors the health of your OpenTelemetry Collectors that are running in Kubernetes. For more on Collectors, see https://docs.lightstep.com/docs/collector-home-page\n\nUse template variables to filter to collector pools and individual collector instances. Filter to a specific collector pool with the `$service.name` template variable. Collector pools running in k8s have a service name that ends with \"collector\"\n\nIf the charts indicate \"No Data Reported\" you may not be sending metrics for that chart."
+      text   = "This dashboard monitors the health of your [OpenTelemetry Collectors](https://opentelemetry.io/docs/collector/) that are running in Kubernetes. For more on Collectors, see https://docs.lightstep.com/docs/collector-home-page\n\nUse template variables to filter to collector pools and individual collector instances. Filter to a specific collector pool with the `$service.name` template variable. Collector pools running in k8s have a service name that ends with \"collector\"\n\nIf the charts indicate \"No Data Reported\" you may not be sending metrics for that chart."
     }
   }
   group {
@@ -556,7 +556,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "Monitor the state of your OpenTelemetry Receivers (https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)\n\nSome receivers like the _hostmetrics_ and _prometheus_ receivers actively obtain telemetry data to place in the collection pipeline. The prometheus receiver can hit scaling issues if there are, say, thousands of prometheus endpoints to scrape. For guidance on scaling and sharding scrapers, see https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers\n\nFor all other information on scaling the receiver, see https://opentelemetry.io/docs/collector/scaling/#how-to-scale"
+      text   = "Monitor the state of your Collector [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md) that accept or scrape telemetry data for collection.\n\nSome receivers like the [_hostmetrics_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md) and [_prometheus_](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/README.md) receivers actively obtain telemetry data to place in the collection pipeline. The prometheus receiver can hit scaling issues if there are, say, thousands of prometheus endpoints to scrape. For guidance on scaling and sharding scrapers, see https://opentelemetry.io/docs/collector/scaling/#scaling-the-scrapers\n\nFor all other information on scaling the receiver, see https://opentelemetry.io/docs/collector/scaling/#how-to-scale"
     }
   }
   group {
@@ -622,69 +622,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Accepted Metric Points"
-      description = "Number of metric points successfully pushed into the next component in the pipeline."
+      name        = "Rate of Refused Metric Points"
+      description = "Number of metric points that were rejected by the next component in the pipeline"
       type        = "timeseries"
       rank        = 3
       x_pos       = 0
       y_pos       = 14
-      width       = 16
-      height      = 8
-
-      query {
-        query_name   = "a"
-        display      = "line"
-        hidden       = false
-        query_string = "metric otelcol_processor_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
-      }
-
-      subtitle = ""
-    }
-    chart {
-      name        = "Rate of Accepted Spans"
-      description = "Number of spans successfully pushed into the next component in the pipeline"
-      type        = "timeseries"
-      rank        = 4
-      x_pos       = 16
-      y_pos       = 14
-      width       = 16
-      height      = 8
-
-      query {
-        query_name   = "a"
-        display      = "line"
-        hidden       = false
-        query_string = "metric otelcol_processor_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
-      }
-
-      subtitle = ""
-    }
-    chart {
-      name        = "Rate of Accepted Log Records"
-      description = "Number of logs successfully pushed into the next component in the pipeline."
-      type        = "timeseries"
-      rank        = 5
-      x_pos       = 32
-      y_pos       = 14
-      width       = 16
-      height      = 8
-
-      query {
-        query_name   = "a"
-        display      = "line"
-        hidden       = false
-        query_string = "metric otelcol_processor_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
-      }
-
-      subtitle = ""
-    }
-    chart {
-      name        = "Rate of Refused Metric Points"
-      description = "Number of metric points that were rejected by the next component in the pipeline"
-      type        = "timeseries"
-      rank        = 6
-      x_pos       = 0
-      y_pos       = 22
       width       = 16
       height      = 8
 
@@ -701,9 +644,9 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       name        = "Rate of Refused Spans"
       description = "Number of Spans that were rejected by the next component in the pipeline."
       type        = "timeseries"
-      rank        = 7
+      rank        = 4
       x_pos       = 16
-      y_pos       = 22
+      y_pos       = 14
       width       = 16
       height      = 8
 
@@ -717,10 +660,86 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "99% Processor Batch Send Size"
-      description = "Distribution of batch send queue size per processor and collector pool in the 99th percentile"
+      name        = "Rate of Refused Log Records"
+      description = "Number of log records that were rejected by the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 5
+      x_pos       = 32
+      y_pos       = 14
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_refused_log_records | filter (((((\"service.name\" == $service_name) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"service.name\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Metric Points"
+      description = "Number of metric points successfully pushed into the next component in the pipeline."
+      type        = "timeseries"
+      rank        = 6
+      x_pos       = 0
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_metric_points | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Spans"
+      description = "Number of spans successfully pushed into the next component in the pipeline"
+      type        = "timeseries"
+      rank        = 7
+      x_pos       = 16
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Rate of Accepted Log Records"
+      description = "Number of logs successfully pushed into the next component in the pipeline."
       type        = "timeseries"
       rank        = 8
+      x_pos       = 32
+      y_pos       = 22
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_accepted_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"processor\"], sum"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "99% Processor Batch Send Size"
+      description = " 99th percentile of the size of batches (in count of metric points, spans, or logs) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end of batch payloads in count of items that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
+      type        = "timeseries"
+      rank        = 9
       x_pos       = 0
       y_pos       = 30
       width       = 16
@@ -736,12 +755,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Rate of Refused Log Records"
-      description = "Number of log records that were rejected by the next component in the pipeline."
+      name        = "99% Processor Batch Send Size in Bytes"
+      description = "99th percentile of the size of batches (in bytes) in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md). This shows the upper end of batch payloads in byte size that will be exported. The batch processor accepts spans, metrics, or logs to better compress the data and send it over fewer outgoing connections."
       type        = "timeseries"
       rank        = 10
-      x_pos       = 32
-      y_pos       = 22
+      x_pos       = 16
+      y_pos       = 30
       width       = 16
       height      = 8
 
@@ -749,7 +768,32 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_processor_refused_log_records | filter (((((\"service.name\" == $service_name) && (\"k8s.pod.uid\" == $pod_uid)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"k8s.pod.name\" == $pod)) | rate | group_by [\"service.name\"], sum"
+        query_string = "metric otelcol_processor_batch_batch_send_size_bytes | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter \"service.name\" == $service_name | delta | group_by [\"processor\", \"service.name\"], distribution | point percentile(value, 99.0)"
+      }
+
+      subtitle = ""
+    }
+    chart {
+      name        = "Batch Processor Triggers"
+      description = "The [batch processor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md) is triggered to send a batch when it exceeds their target size or after a timeout, whichever happens first. This chart shows the balance between size and timeout triggers. Adjust the batch processor by configuring `send_batch_size`, `send_batch_max_size`, and `timeout`."
+      type        = "timeseries"
+      rank        = 12
+      x_pos       = 32
+      y_pos       = 30
+      width       = 16
+      height      = 8
+
+      query {
+        query_name   = "a"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_batch_timeout_trigger_send | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | delta | group_by [\"processor\", \"service.name\"], sum"
+      }
+      query {
+        query_name   = "b"
+        display      = "line"
+        hidden       = false
+        query_string = "metric otelcol_processor_batch_batch_size_trigger_send | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | delta | group_by [\"processor\", \"service.name\"], sum"
       }
 
       subtitle = ""
@@ -761,7 +805,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 6
-      text   = "Processors are optional components that run on data between being received and being exported. If your collectors do not include any processors, these charts will be empty.\n\nIn the case of memory_limiter implementations, new data will be blocked from passing through the pipeline by the memory_limiter, and show up in the Refused Spans chart. For more information:  https://opentelemetry.io/docs/collector/scaling/#when-to-scale \n\nFor more information on processors: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md"
+      text   = "Monitor the state of your Collector [Processors](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/README.md) that operate on received telemetry before it is exported. Processors are optional components, and if your collectors do not include any processors, these charts will be empty.\n\nIn the case of the [_memory_limiter_](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/memorylimiterprocessor/README.md) processor, new telemetry data will be blocked from passing through the pipeline by the _memory_limiter_, and show up in the Refused Metric Points, Spans, or Log Records charts. If telemetry is regularly refused due to memory limits, you likely need to scale up your cluster.\n\nFor more information, see https://opentelemetry.io/docs/collector/scaling/#when-to-scale "
     }
   }
   group {
@@ -789,12 +833,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Failed Spans"
-      description = "Number of spans in failed attempts to send to destination, including Cloud Observability"
+      name        = "Sent Spans"
+      description = "Number of spans successfully sent to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 1
       x_pos       = 16
-      y_pos       = 15
+      y_pos       = 7
       width       = 16
       height      = 8
 
@@ -802,7 +846,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_enqueue_failed_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+        query_string = "metric otelcol_exporter_sent_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
       }
 
       subtitle = ""
@@ -846,12 +890,12 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Sent Spans"
-      description = "Number of spans successfully sent to destination, including Cloud Observability"
+      name        = "Failed Spans"
+      description = "Number of spans in failed attempts to send to destination, including Cloud Observability"
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
-      y_pos       = 7
+      y_pos       = 15
       width       = 16
       height      = 8
 
@@ -859,7 +903,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_sent_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+        query_string = "metric otelcol_exporter_enqueue_failed_spans | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
       }
 
       subtitle = ""
@@ -947,7 +991,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 7
-      text   = "Monitor the Queue Usage chart to ensure data isn't piling up. The Collector will queue data in memory while waiting for a worker to become available to send the data. If there aren’t enough workers or the backend is too slow, data starts piling up in the queue. \n\nAn increase in the Failed Spans chart indicates that sending data to the backend failed permanently and further triage is needed.\n\nFor more information on scaling refer to the OpenTelemetry documentation: https://opentelemetry.io/docs/collector/scaling/#how-to-scale\n\nFor more information on exporters: https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md"
+      text   = "Monitor the state of your Collector [Exporters](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md) that send telemetry to CloudObs and any other configured destinations.\n\nCheck the Queue Usage chart to ensure data isn't piling up. The collector will queue data in memory while waiting for a worker to become available to send the data. If there aren’t enough workers or the backend is too slow, data starts piling up in the queue. Increasing the queue size might alleviate pressure on the backend destination in this case.\n\nAn increase in the Failed Spans chart indicates that sending data to the backend failed permanently and further triage is needed.\n"
     }
   }
   group {
@@ -988,7 +1032,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "with\n  usage = metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\n  available = metric k8s.pod.memory.available | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\njoin usage / available * 100, usage=0, available=1"
+        query_string = "with\n  usage = metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\n  available = metric k8s.pod.memory.available | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest | group_by [\"service.name\"], sum;\njoin usage / available * 100.0, usage=0, available=1"
       }
 
       subtitle = ""
@@ -1032,8 +1076,8 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Memory Used Per Pool"
-      description = "Distribution of memory used by the pods in each Collector pool"
+      name        = "99% Memory Used Per Pool"
+      description = "99th percentile of memory used by the pods in each collector pool. This shows the upper end of memory usage across the collector pods in a pool in absolute terms."
       type        = "timeseries"
       rank        = 4
       x_pos       = 16
@@ -1043,9 +1087,9 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
 
       query {
         query_name   = "a"
-        display      = "heatmap"
+        display      = "line"
         hidden       = false
-        query_string = "metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [\"service.name\"], distribution"
+        query_string = "metric k8s.pod.memory.usage | filter k8s.pod.uid == $pod_uid | filter k8s.pod.name == $pod | filter k8s.cluster.name == $cluster | filter k8s.namespace.name == $namespace | filter service.name == $service_name | filter service.name =~ \".*collector\" | latest 1m | group_by [\"service.name\"], distribution | point percentile(value, 99.0)"
       }
 
       subtitle = ""
@@ -1076,7 +1120,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       y_pos  = 0
       width  = 48
       height = 5
-      text   = "Examine CPU and memory utilization, if you see extended CPU or memory utilization coinciding with container restarts it may indicate a scaling issue. Other symptoms may include dropped telemetry. \n\nIf data is frequently refused due to memory limits, consider scaling up. For more information on scaling see: https://docs.lightstep.com/docs/kubernetes-collector-tracing-scaling "
+      text   = "Examine CPU and memory utilization. CPU or memory utilization approaching their capacity limits or coinciding with container restarts may indicate a scaling issue. Other symptoms may include dropped telemetry. \n\nIf data is frequently refused due to memory limits, consider scaling up. For more information on scaling see: https://docs.lightstep.com/docs/kubernetes-collector-tracing-scaling "
     }
   }
   group {


### PR DESCRIPTION

![Screenshot 2023-09-28 at 10 10 06 AM](https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/87725682/e49b5ffb-77d4-4754-ad08-a7e02393cfc3)
## Description
What does this PR do?
This PR iterates on the existing Collector Dashboard. It adds the following sections:

1. Overview
2. Processor
3. Receiver
4. Exporter
5. Resource Usage
6. Pod Phases

In addition, it adds text panels providing information on things to look for when triaging, links to documentation on scaling, and chart level descriptions.

## PR checklist

Please confirm the following items:
- [x] At least one screenshot of the proposed dashboard is included in this PR. If you're proposing substantive changes to queries or new queries then please ensure your screenshot shows relevant data.
- [x] All chart names are in [Title case](https://en.wikipedia.org/wiki/Title_case).
- [x] All query names are lower case letters, beginning the first query of each chart as "a" and proceeding alphabetically ... "b", "c", etcetera.
