### PR TITLE
ls-52046 renaming a chart that was causing issues for tests

### DIFF
--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -307,7 +307,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "List of Total Pods Per Pool"
+      name        = "Number Of Pods Per Pool"
       description = "Count Of total Kubernetes pods per pool"
       type        = "timeseries"
       rank        = 6

--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -307,7 +307,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
       subtitle = ""
     }
     chart {
-      name        = "Total Pods Per Pool"
+      name        = "List of Total Pods Per Pool"
       description = "Count Of total Kubernetes pods per pool"
       type        = "timeseries"
       rank        = 6


### PR DESCRIPTION
## Description
What does this PR do?

Renames a chart from `Total Pods Per Pool` to `Number of Pods Per Pool` that was causing test failures due to 2 charts having the same name in a group on this dashboard.

## PR checklist

Please confirm the following items:
- [ ] At least one screenshot of the proposed dashboard is included in this PR. If you're proposing substantive changes to queries or new queries then please ensure your screenshot shows relevant data.
- [ ] All chart names are in [Title case](https://en.wikipedia.org/wiki/Title_case).
- [ ] All query names are lower case letters, beginning the first query of each chart as "a" and proceeding alphabetically ... "b", "c", etcetera.
