### PR TITLE
ls-55951-collector-health-dashboard-exporter-chart-query-fixes

### DIFF
--- a/collector-dashboards/otel-collector-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-dashboard/main.tf
@@ -882,7 +882,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_enqueue_sent_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+        query_string = "metric otelcol_exporter_sent_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
       }
 
       subtitle = ""
@@ -939,7 +939,7 @@ resource "lightstep_dashboard" "otel_collector_dashboard" {
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "metric otelcol_exporter_enqueue_failed_to_send_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
+        query_string = "metric otelcol_exporter_enqueue_failed_log_records | filter (((((\"k8s.pod.uid\" == $pod_uid) && (\"k8s.pod.name\" == $pod)) && (\"k8s.cluster.name\" == $cluster)) && (\"k8s.namespace.name\" == $namespace)) && (\"service.name\" == $service_name)) | rate | group_by [\"service.name\", \"exporter\"], sum"
       }
 
       subtitle = ""


### PR DESCRIPTION
## Description
What does this PR do?
Fixes some incorrect metric names in the Collector Health Dashboard - Exporter section charts that would not generate the right chart.

1) I changed the metric `otelcol_exporter_enqueue_sent_log_records` to `otelcol_exporter_sent_log_records `
2) I changed the metric `otelcol_exporter_enqueue_failed_to_send_log_records` to `otelcol_exporter_enqueue_failed_log_records`

## PR checklist

Please confirm the following items:
- [x ] At least one screenshot of the proposed dashboard is included in this PR. If you're proposing substantive changes to queries or new queries then please ensure your screenshot shows relevant data.
- [ x] All chart names are in [Title case](https://en.wikipedia.org/wiki/Title_case).
- [ x] All query names are lower case letters, beginning the first query of each chart as "a" and proceeding alphabetically ... "b", "c", etcetera.
![image](https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/87725682/75d773d3-74a0-4820-b61c-4057fee56241)
