### PR TITLE
kubernetes-comprehensive: fix daemonset total chart

### DIFF
--- a/collector-dashboards/otel-collector-kubernetes-comprehensive-dashboard/main.tf
+++ b/collector-dashboards/otel-collector-kubernetes-comprehensive-dashboard/main.tf
@@ -291,7 +291,7 @@ resource "lightstep_dashboard" "otel_collector_kubernetes_comprehensive_dashboar
         query_name   = "a"
         display      = "line"
         hidden       = false
-        query_string = "with\n  a = metric k8s.daemonset.ready_nodes | filter k8s.cluster.name == $cluster && k8s.namespace.name == $namespace | latest | group_by [], sum;\n  b = metric kube_daemonset_status_number_unavailable | filter k8s.namespace.name == $namespace | latest | group_by [], sum;\njoin ((a + b)), a=0, b=0"
+        query_string = "metric k8s.daemonset.ready_nodes | filter k8s.cluster.name == $cluster && k8s.namespace.name == $namespace | latest | group_by [], sum"
       }
     }
     chart {


### PR DESCRIPTION
## Description
What does this PR do?
Fix "Daemonset Total" chart in the kubernetes comprehensive dashboard. There is no equivalent `kube_daemonset_status_number_unavailable` metric in the otel collector k8s receiver, we should just skip it - and probably open a ticket in the k8s receiver to start sending this information.

Before:
![image](https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/7898464/783bb6d8-30c5-4bc1-9472-8357d332f884)

After:
![image](https://github.com/lightstep/terraform-opentelemetry-dashboards/assets/7898464/f71335cd-2297-48f3-aa13-a1acc9be1439)



## PR checklist

Please confirm the following items:
- [x] At least one screenshot of the proposed dashboard is included in this PR. If you're proposing substantive changes to queries or new queries then please ensure your screenshot shows relevant data.
- [x] All chart names are in [Title case](https://en.wikipedia.org/wiki/Title_case).
- [x] All query names are lower case letters, beginning the first query of each chart as "a" and proceeding alphabetically ... "b", "c", etcetera.
